### PR TITLE
Add healthcheck response for GET / that ignores authorization headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "split-evaluator",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Split SDK web services",
   "main": "server.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -23,10 +23,8 @@ const port = process.env.SPLITIO_SERVER_PORT || 7548;
 const EXT_API_KEY = process.env.SPLITIO_EXT_API_KEY;
 
 // Healthcheck used by kubernetes does not check api key
-app.get('/', (req, res) => {
-  res.send({
-    health: "OK"
-  });
+app.get('/admin/ping', (req, res) => {
+  res.send("pong");
 });
 
 if (!EXT_API_KEY) {

--- a/server.js
+++ b/server.js
@@ -22,6 +22,13 @@ const manager = api.manager();
 const port = process.env.SPLITIO_SERVER_PORT || 7548;
 const EXT_API_KEY = process.env.SPLITIO_EXT_API_KEY;
 
+// Healthcheck used by kubernetes does not check api key
+app.get('/', (req, res) => {
+  res.send({
+    health: "OK"
+  });
+});
+
 if (!EXT_API_KEY) {
   console[console.warn ? 'warn' : 'log']('External API key not provided. If you want a security filter use the EXT_API_KEY environment variable as explained on the README file.');
 }


### PR DESCRIPTION
Required to deploy with kubernetes: https://cloud.google.com/container-engine/docs/tutorials/http-balancer#remarks