### PR TITLE
[SDKS-930]: Re-structure Split-Evaluator and move actual logic

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Split Evaluator
+
+## Tickets covered:
+* [SDKS-{TICKET}:](https://splitio.atlassian.net/browse/SDKS-{TICKET})
+
+## What did you accomplish?
+* Bullet 1
+* Bullet 2
+
+## How to test new changes?
+
+## Extra Notes
+* Bullet 1
+* Bullet 2
+
+## Version candidate
+* `{version}`

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+
+node_js:
+  - "lts/*"
+
+cache: npm
+
+before_script:
+  - npm install
+
+script:
+  - npm run lint

--- a/admin/admin.controller.js
+++ b/admin/admin.controller.js
@@ -1,8 +1,4 @@
-/**
- * To be mounted at /admin
- */
-const express = require('express');
-const router = express.Router();
+'use strict';
 
 const os = require('os');
 const ip = require('ip');
@@ -12,18 +8,23 @@ const sdkModule = require('../sdk');
 const sdk = sdkModule.factory;
 
 /**
- * ping method, just that.
+ * ping pings server
+ * @param {*} req 
+ * @param {*} res 
  */
-router.get('/ping', (req, res) => {
+const ping = (req, res) => {
   console.log('pong');
   res.status(200).send('pong');
-});
+};
+
 /**
- * health check method. Will respond according to SDK status. Two options:
- *    200 - Everything is OK. Ready to evaluate.
- *    500 - Something is wrong or not ready yet. Not able to perform evaluations.
+ * healthcheck  checks if SDK and environtment is healthy or not.
+ * 200 - Everything is OK. Ready to evaluate.
+ * 500 - Something is wrong or not ready yet. Not able to perform evaluations.
+ * @param {*} req 
+ * @param {*} res 
  */
-router.get('/healthcheck', (req, res) => {
+const healthcheck = (req, res) => {
   console.log('Running health check.');
   let status = 500;
   let msg = 'Split evaluator engine is not evaluating traffic properly.';
@@ -35,11 +36,14 @@ router.get('/healthcheck', (req, res) => {
 
   console.log('Health check status: ' + status + ' - ' + msg);
   res.status(status).send(msg);
-});
+};
+
 /**
- * version method. Returns the version of the Split evaluator and the SDK type and version.
+ * version  returns the current version of Split Evaluator
+ * @param {*} req 
+ * @param {*} res 
  */
-router.get('/version', (req, res) => {
+const version = (req, res) => {
   console.log('Getting version.');
   const version = utils.getVersion();
   const parts = sdk.settings.version.split('-');
@@ -51,11 +55,14 @@ router.get('/version', (req, res) => {
     sdk: sdkLanguage,
     sdkVersion
   });
-});
+};
+
 /**
- * Returns some data from the machine running the evaluator, ip and hostname.
+ * machine  returns the machine instance name and machine ip
+ * @param {*} req 
+ * @param {*} res 
  */
-router.get('/machine', (req, res) => {
+const machine = (req, res) => {
   console.log('Getting machine information.');
   let address; let hostname;
 
@@ -70,14 +77,23 @@ router.get('/machine', (req, res) => {
     ip: address,
     name: hostname
   });
-});
+};
+
 /**
- * Returns the uptime of the server.
+ * uptime returns the uptime of the server
+ * @param {*} req 
+ * @param {*} res 
  */
-router.get('/uptime', (req, res) => {
+const uptime = (req, res) => {
   const uptime = utils.uptime();
   console.log('Getting uptime: ' + uptime);
   res.send('' + uptime);
-});
+};
 
-module.exports = router;
+module.exports = {
+  ping,
+  healthcheck,
+  version,
+  machine,
+  uptime,
+};

--- a/admin/admin.controller.js
+++ b/admin/admin.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const os = require('os');
 const ip = require('ip');
 

--- a/admin/admin.router.js
+++ b/admin/admin.router.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const adminController = require('./admin.controller');
+
+router.get('/ping', adminController.ping);
+router.get('/healthcheck', adminController.healthcheck);
+router.get('/version', adminController.version);
+router.get('/machine', adminController.machine);
+router.get('/uptime', adminController.uptime);
+
+module.exports = router;

--- a/admin/admin.router.js
+++ b/admin/admin.router.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const express = require('express');
 const router = express.Router();
 const adminController = require('./admin.controller');

--- a/client/client.controller.js
+++ b/client/client.controller.js
@@ -1,24 +1,26 @@
-/**
- * To be mounted at / (root).
- */
-const express = require('express');
-const router = express.Router();
+'use strict';
+
 // Utils
 const thenable = require('@splitsoftware/splitio/lib/utils/promise/thenable');
 const reduce = require('lodash/reduce');
 const map = require('lodash/map');
 const config = require('config');
+
 // Own modules
 const utils = require('../utils');
+const common = require('./common');
 const sdkModule = require('../sdk');
+
 // Client and manager we will use
 const client = sdkModule.client;
 const manager = sdkModule.manager;
 
 /**
- * get-treatment endpoint. Evaluates a given split.
+ * getTreatment evaluates a given split-name
+ * @param {*} req 
+ * @param {*} res 
  */
-router.get('/get-treatment', (req, res) => {
+const getTreatment = (req, res) => {
   console.log('Getting a treatment.');  
   const state = req.query;
   const key = utils.parseKey(state.key, state['bucketing-key']);
@@ -47,12 +49,14 @@ router.get('/get-treatment', (req, res) => {
 
   if (thenable(eventuallyAvailableValue)) eventuallyAvailableValue.then(asyncResult);
   else asyncResult(eventuallyAvailableValue);
-});
+};
+
 /**
- * get-treatments endpoint. 
- * Returns the evaluations for all treatments matching the traffic type of the provided keys.
+ * getTreatments  returns the evaluations for all treatments matching the traffic type of the provided keys.
+ * @param {*} req 
+ * @param {*} res 
  */
-router.get('/get-treatments', (req, res) => {
+const getTreatments = (req, res) => {
   console.log('Getting treatments.');    
   const state = req.query;
   let keys = [];
@@ -80,7 +84,7 @@ router.get('/get-treatments', (req, res) => {
       return {
         trafficType: key.trafficType,
         key: utils.parseKey(key.matchingKey, key.bucketingKey),
-        splits: filterSplitsByTT(views, key.trafficType)
+        splits: common.filterSplitsByTT(views, key.trafficType)
       };
     });
   });
@@ -109,20 +113,9 @@ router.get('/get-treatments', (req, res) => {
     })
     // 500 on error
     .catch(() => res.sendStatus(500));
-});
+};
 
-/**
- * Utility function. Reduces a collection of split views to a list of names of the splits
- * corresponding to the given traffic type.
- */
-function filterSplitsByTT(splitViews, trafficType) {
-  return reduce(splitViews, (acc, view) => {
-    if (view.trafficType === trafficType) {
-      acc.push(view.name);
-    }
-    return acc;
-  }, []);
-}
-
-module.exports = router;
-
+module.exports = {
+  getTreatment,
+  getTreatments,
+};

--- a/client/client.controller.js
+++ b/client/client.controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Utils
 const thenable = require('@splitsoftware/splitio/lib/utils/promise/thenable');
 const reduce = require('lodash/reduce');

--- a/client/client.router.js
+++ b/client/client.router.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const clientController = require('./client.controller');
+
+router.get('/get-treatment', clientController.getTreatment);
+router.get('/get-treatments', clientController.getTreatments);
+
+module.exports = router;

--- a/client/client.router.js
+++ b/client/client.router.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const express = require('express');
 const router = express.Router();
 const clientController = require('./client.controller');

--- a/client/common.js
+++ b/client/common.js
@@ -1,8 +1,10 @@
 const reduce = require('lodash/reduce');
 
 /**
- * Utility function. Reduces a collection of split views to a list of names of the splits
+ * filterSplitsByTT Reduces a collection of split views to a list of names of the splits
  * corresponding to the given traffic type.
+ * @param object splitViews 
+ * @param string trafficType 
  */
 const filterSplitsByTT = (splitViews, trafficType) => {
   return reduce(splitViews, (acc, view) => {

--- a/client/common.js
+++ b/client/common.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const reduce = require('lodash/reduce');
+
+/**
+ * Utility function. Reduces a collection of split views to a list of names of the splits
+ * corresponding to the given traffic type.
+ */
+const filterSplitsByTT = (splitViews, trafficType) => {
+  return reduce(splitViews, (acc, view) => {
+    if (view.trafficType === trafficType) {
+      acc.push(view.name);
+    }
+    return acc;
+  }, []);
+};
+
+module.exports = {
+  filterSplitsByTT,
+};

--- a/client/common.js
+++ b/client/common.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const reduce = require('lodash/reduce');
 
 /**

--- a/middleware/authorization.js
+++ b/middleware/authorization.js
@@ -1,0 +1,14 @@
+const EXT_API_KEY = process.env.SPLITIO_EXT_API_KEY;
+
+const authorization = (req, res, next) => {
+  if (!EXT_API_KEY || req.headers.authorization === EXT_API_KEY) {
+    next();
+  } else {
+    console.log('Returning 401 Unauthorized.');
+    res.status(401).send('Unauthorized');
+  }
+};
+
+module.exports = {
+  authorization,
+};

--- a/middleware/authorization.js
+++ b/middleware/authorization.js
@@ -16,6 +16,4 @@ const authorization = (req, res, next) => {
   }
 };
 
-module.exports = {
-  authorization,
-};
+module.exports = authorization;

--- a/middleware/authorization.js
+++ b/middleware/authorization.js
@@ -1,5 +1,12 @@
 const EXT_API_KEY = process.env.SPLITIO_EXT_API_KEY;
 
+/**
+ * authorization  checks if EXT_API_KEY matches with the one passed
+ * as header
+ * @param {*} req 
+ * @param {*} res 
+ * @param {*} next 
+ */
 const authorization = (req, res, next) => {
   if (!EXT_API_KEY || req.headers.authorization === EXT_API_KEY) {
     next();

--- a/sdk.js
+++ b/sdk.js
@@ -1,7 +1,6 @@
 //
 // SDK initialization and factory instanciation.
 //
-'use strict';
 
 const SplitFactory = require('@splitsoftware/splitio').SplitFactory;
 const config = require('config');

--- a/server.js
+++ b/server.js
@@ -1,11 +1,13 @@
-'use strict';
-
 const express = require('express');
 const app = express();
 const config = require('config');
 const utils = require('./utils');
+
 // Used for BUR
 const client = require('./sdk').client;
+
+// Middlewares
+const authorization = require('./middleware/authorization').authorization;
 
 const clientRouter = require('./client/client.router');
 const adminRouter = require('./admin/admin.router');
@@ -17,14 +19,7 @@ if (!EXT_API_KEY) {
   console[console.warn ? 'warn' : 'log']('External API key not provided. If you want a security filter use the EXT_API_KEY environment variable as explained on the README file.');
 }
 // Auth middleware
-app.use((req, res, next) => {
-  if (!EXT_API_KEY || req.headers.authorization === EXT_API_KEY) {
-    next();
-  } else {
-    console.log('Returning 401 Unauthorized.');
-    res.status(401).send('Unauthorized');
-  }
-});
+app.use(authorization);
 // We mount our routers.
 app.use('/', clientRouter);
 app.use('/admin', adminRouter);

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const utils = require('./utils');
 const client = require('./sdk').client;
 
 // Middlewares
-const authorization = require('./middleware/authorization').authorization;
+const authorization = require('./middleware/authorization');
 
 const clientRouter = require('./client/client.router');
 const adminRouter = require('./admin/admin.router');

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const utils = require('./utils');
 // Used for BUR
 const client = require('./sdk').client;
 
-const evaluatorRouter = require('./routes/evaluator');
+const clientRouter = require('./client/client.router');
 const adminRouter = require('./admin/admin.router');
 
 const PORT = process.env.SPLITIO_SERVER_PORT || 7548;
@@ -26,7 +26,7 @@ app.use((req, res, next) => {
   }
 });
 // We mount our routers.
-app.use('/', evaluatorRouter);
+app.use('/', clientRouter);
 app.use('/admin', adminRouter);
 
 //Route not found -- Set 404

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const utils = require('./utils');
 const client = require('./sdk').client;
 
 const evaluatorRouter = require('./routes/evaluator');
-const adminRouter = require('./routes/admin');
+const adminRouter = require('./admin/admin.router');
 
 const PORT = process.env.SPLITIO_SERVER_PORT || 7548;
 const EXT_API_KEY = process.env.SPLITIO_EXT_API_KEY;

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const packageJson = require('./package.json');
 
 /**


### PR DESCRIPTION
# Split Evaluator

## Tickets covered:
* [SDKS-930: Re-structure Split-Evaluator and move actual logic](https://splitio.atlassian.net/browse/SDKS-930)

## What did you accomplish?
* Added `middleware` package.
* Moved authorization validation into `authorization` module.
* Moved `evaluator` module to `client` package and separated `routes` from `controllers`.
* Moved `admin` module to `admin` package and separated `routes` from `controllers`.
* Added `pull_request_template`