### PR TITLE
Feature/do not send ip

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.0.2 (October XX, 2019)
+- Added setting SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED to disable reporting IP Addresses and Machine name back to Split cloud.
+
 2.0.1 (September 26, 2019)
 - Updated url regex to accept: `-`.`_` and digits.
 - Updated SDK version to v10.8.4 which is the latest stable to the date.

--- a/listener/__tests__/ip-addresses.test.js
+++ b/listener/__tests__/ip-addresses.test.js
@@ -1,0 +1,87 @@
+
+
+const request = require('supertest');
+const { expectOk } = require('../../utils/testWrapper/index');
+
+describe('ip addresses', () => {
+  let ip;
+  let hostname;
+
+  const log = (impressionData) => {
+    ip = impressionData.ip;
+    hostname = impressionData.hostname;
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  describe('ip addresses default', () => {
+    test('should set hostname and ip when is default', async (done) => {
+      process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
+      process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
+      process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT = 'http://localhost:7546';
+      const app = require('../../app');
+      const os = require('os');
+      const localIp = require('ip');
+  
+      const sdkModule = require('../../sdk');
+      sdkModule.factory.settings.impressionListener.logImpression = log;
+  
+      const response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment')
+        .set('Authorization', 'test');
+      expectOk(response, 200, 'on', 'my-experiment');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(ip).toBe(localIp.address());
+      expect(hostname).toBe(os.hostname());
+      done();
+    });
+  });
+
+  describe('ip addresses disabled', () => {
+    test('should not set hostname and ip when is false', async (done) => {
+      process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
+      process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
+      process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT = 'http://localhost:7546';
+      process.env.SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED = 'false';
+      const app = require('../../app');
+
+      const sdkModule = require('../../sdk');
+      sdkModule.factory.settings.impressionListener.logImpression = log;
+
+      const response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment')
+        .set('Authorization', 'test');
+      expectOk(response, 200, 'on', 'my-experiment');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(ip).toBe(false);
+      expect(hostname).toBe(false);
+      done();
+    });
+  });
+
+  describe('ip addresses enabled', () => {
+    test('should set hostname and ip when is true', async (done) => {
+      process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
+      process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
+      process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT = 'http://localhost:7546';
+      process.env.SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED = 'true';
+      const app = require('../../app');
+      const os = require('os');
+      const localIp = require('ip');
+  
+      const sdkModule = require('../../sdk');
+      sdkModule.factory.settings.impressionListener.logImpression = log;
+  
+      const response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment')
+        .set('Authorization', 'test');
+      expectOk(response, 200, 'on', 'my-experiment');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(ip).toBe(localIp.address());
+      expect(hostname).toBe(os.hostname());
+      done();
+    });
+  });
+});

--- a/listener/__tests__/ip-addresses.test.js
+++ b/listener/__tests__/ip-addresses.test.js
@@ -1,5 +1,3 @@
-
-
 const request = require('supertest');
 const { expectOk } = require('../../utils/testWrapper/index');
 

--- a/listener/__tests__/listener.test.js
+++ b/listener/__tests__/listener.test.js
@@ -101,4 +101,4 @@ describe('impression-listener', () => {
   afterAll(done => {
     server.close(done);
   });
-});  
+});

--- a/listener/index.js
+++ b/listener/index.js
@@ -12,4 +12,6 @@ const logImpression = (impressionData) => {
   impressionManager.trackImpression(impressionData.impression);
 };
 
-module.exports = logImpression;
+module.exports = {
+  logImpression,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1042,9 +1042,9 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.8.4",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.8.4.tgz",
-      "integrity": "sha512-3/f8PuugDcpq9H6HZ63gol/GJ2PYOx+m4+qulTpDWL/YdZBE5qIJTuyyP3BVKdVVWMSbuheEbzluXw11N4ODmw==",
+      "version": "10.9.0-cannary.0",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.9.0-cannary.0.tgz",
+      "integrity": "sha512-6xGmsEf8auYZwyk4lBB2dcFDgh3WprrmQRVyNkJa1SZen1dw5BKvwBCT4WQelNuuh0TmIAuxRH0oaKmHSnthxA==",
       "requires": {
         "@types/node": "10.9.4",
         "axios": "0.19.0",
@@ -1497,9 +1497,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
       "optional": true
     },
     "body-parser": {
@@ -1986,9 +1986,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
     },
     "core-js-compat": {
       "version": "3.2.1",
@@ -3904,9 +3904,9 @@
       }
     },
     "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
       "version": "1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -801,6 +801,15 @@
         }
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.6.3.tgz",
+      "integrity": "sha512-933SXHQr7apa95F+3IqkBne8mqOnu1kDh6dnSddC07aW/R51WsOVD7MSczJ6DRpq/L8KLll7TFDxmt30pft44w==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -1042,15 +1051,16 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.9.0-cannary.0",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.9.0-cannary.0.tgz",
-      "integrity": "sha512-6xGmsEf8auYZwyk4lBB2dcFDgh3WprrmQRVyNkJa1SZen1dw5BKvwBCT4WQelNuuh0TmIAuxRH0oaKmHSnthxA==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.9.0.tgz",
+      "integrity": "sha512-9+NNulcU3avVDiUJqANP+AwoZAZ/c3bJHBhHZezF+HwYhja+hH8WCNykVW7mdD9f7TtVc3sxWmhPFz29tx0Z3Q==",
       "requires": {
-        "@types/node": "10.9.4",
+        "@babel/runtime-corejs3": "^7.6.3",
+        "@types/node": "^12.11.7",
         "axios": "0.19.0",
-        "babel-runtime": "6.26.0",
+        "core-js": "3.3.3",
         "events": "3.0.0",
-        "ioredis": "3.2.2",
+        "ioredis": "^4.14.1",
         "ip": "1.1.5",
         "js-yaml": "3.13.1",
         "utfx": "1.0.1"
@@ -1123,9 +1133,9 @@
       }
     },
     "@types/node": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
+      "version": "12.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
+      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1404,15 +1414,6 @@
         "babel-plugin-jest-hoist": "^24.6.0"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1495,12 +1496,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
-    },
-    "bluebird": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
-      "optional": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -1986,9 +1981,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.3.tgz",
+      "integrity": "sha512-0xmD4vUJRY8nfLyV9zcpC17FtSie5STXzw+HyYw2t8IIvmDnbq7RJUULECCo+NstpJtwK9kx8S+898iyqgeUow=="
     },
     "core-js-compat": {
       "version": "3.2.1",
@@ -1999,6 +1994,11 @@
         "browserslist": "^4.6.6",
         "semver": "^6.3.0"
       }
+    },
+    "core-js-pure": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.3.4.tgz",
+      "integrity": "sha512-hqxt6XpR4zIMNUY920oNyAtwaq4yg8IScmXumnfyRWF9+ur7wtjr/4eCdfTJzY64jmi8WRCwIqNBKzYeOKdvnw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2846,12 +2846,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
-    },
-    "flexbuffer": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
-      "integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA=",
-      "optional": true
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -3811,44 +3805,36 @@
       "dev": true
     },
     "ioredis": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-3.2.2.tgz",
-      "integrity": "sha512-g+ShTQYLsCcOUkNOK6CCEZbj3aRDVPw3WOwXk+LxlUKvuS9ujEqP2MppBHyRVYrNNFW/vcPaTBUZ2ctGNSiOCA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.1.tgz",
+      "integrity": "sha512-94W+X//GHM+1GJvDk6JPc+8qlM7Dul+9K+lg3/aHixPN7ZGkW6qlvX0DG6At9hWtH2v3B32myfZqWoANUJYGJA==",
       "optional": true,
       "requires": {
-        "bluebird": "^3.3.4",
-        "cluster-key-slot": "^1.0.6",
-        "debug": "^2.6.9",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.1.1",
         "denque": "^1.1.0",
-        "flexbuffer": "0.0.6",
-        "lodash.assign": "^4.2.0",
-        "lodash.bind": "^4.2.1",
-        "lodash.clone": "^4.5.0",
-        "lodash.clonedeep": "^4.5.0",
         "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
         "lodash.flatten": "^4.4.0",
-        "lodash.foreach": "^4.5.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.keys": "^4.2.0",
-        "lodash.noop": "^3.0.1",
-        "lodash.partial": "^4.2.1",
-        "lodash.pick": "^4.4.0",
-        "lodash.sample": "^4.2.1",
-        "lodash.shuffle": "^4.2.0",
-        "lodash.values": "^4.3.0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.4.0"
+        "redis-commands": "1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.0.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "optional": true
         }
       }
     },
@@ -4857,40 +4843,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "optional": true
-    },
-    "lodash.bind": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
-      "optional": true
-    },
-    "lodash.clone": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
-      "optional": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "optional": true
-    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "optional": true
-    },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
       "optional": true
     },
     "lodash.flatten": {
@@ -4899,65 +4855,11 @@
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "optional": true
     },
-    "lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
-      "optional": true
-    },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
-      "optional": true
-    },
-    "lodash.keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
-      "optional": true
-    },
-    "lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw=",
-      "optional": true
-    },
-    "lodash.partial": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.partial/-/lodash.partial-4.2.1.tgz",
-      "integrity": "sha1-SfPYz9qjv/izqR0SfpIyRUGJYdQ=",
-      "optional": true
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "optional": true
-    },
-    "lodash.sample": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.sample/-/lodash.sample-4.2.1.tgz",
-      "integrity": "sha1-XkKRsMdT+hq+sKq4+ynfG2bwf20=",
-      "optional": true
-    },
-    "lodash.shuffle": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
-      "integrity": "sha1-FFtQU8+HX29cKjP0i26ZSMbse0s=",
-      "optional": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
-    },
-    "lodash.values": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
-      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5979,11 +5881,20 @@
       "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==",
       "optional": true
     },
-    "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
       "optional": true
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "optional": true,
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
     },
     "regenerate": {
       "version": "1.4.0",
@@ -6001,9 +5912,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -6715,6 +6626,12 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
+    },
+    "standard-as-callback": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.0.1.tgz",
+      "integrity": "sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==",
+      "optional": true
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
-    "@splitsoftware/splitio": "^10.9.0-canary.1",
+    "@splitsoftware/splitio": "^10.9.0",
     "config": "1.25.1",
     "express": "^4.17.1",
     "morgan": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
-    "@splitsoftware/splitio": "^10.8.4",
+    "@splitsoftware/splitio": "^10.9.0-canary.1",
     "config": "1.25.1",
     "express": "^4.17.1",
     "morgan": "^1.9.1",

--- a/utils/parserConfigs/__tests__/index.test.js
+++ b/utils/parserConfigs/__tests__/index.test.js
@@ -69,6 +69,22 @@ describe('getConfigs', () => {
     done();
   });
 
+  test('ipAddressesEnabled', done => {
+    // Test ok
+    process.env.SPLIT_EVALUATOR_API_KEY = 'something';
+    expect(() => settings().not.toThrow());
+
+    process.env.SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED = 'false';
+    expect(() => settings().not.toThrow());
+
+    const options = settings();
+    expect(options).toHaveProperty('core', { authorizationKey: 'something', IPAddressesEnabled: false });
+    expect(options).not.toHaveProperty('impressionListener');
+    expect(options).not.toHaveProperty('scheduler');
+    expect(options).not.toHaveProperty('urls');
+    done();
+  });
+
   test('listener', done => {
     // Test empty
     process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT = '';
@@ -86,6 +102,8 @@ describe('getConfigs', () => {
     expect(() => settings().toThrow());
 
     process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT = 'http://localhost:1111/impressions';
+
+    process.env.SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED = null;
 
     const options = settings();
     expect(options).toHaveProperty('core', { authorizationKey: 'something'});
@@ -129,6 +147,8 @@ describe('getConfigs', () => {
 
     process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT = 'https://127.0.0.1';
     expect(() => settings().not.toThrow());
+
+    process.env.SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED = null;
 
     const options = settings();
     expect(options).toHaveProperty('core', { authorizationKey: 'something'});

--- a/utils/parserConfigs/index.js
+++ b/utils/parserConfigs/index.js
@@ -48,10 +48,13 @@ const getConfigs = () => {
   // IMPRESSION LISTENER
   if (process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT && validUrl('SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT')) {
     console.log('Setting impression listener.');
-    const logImpression = require('../../listener/');
-    configs.impressionListener = {
-      logImpression,
-    };
+    const impressionListener = require('../../listener/');
+    configs.impressionListener = impressionListener;
+  }
+
+  // IP ADDRESS ENABLED
+  if (process.env.SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED && process.env.SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED.toLowerCase() === 'false') {
+    configs.core.IPAddressesEnabled = false;
   }
 
   if (Object.keys(scheduler).length > 0) {
@@ -63,7 +66,7 @@ const getConfigs = () => {
     console.log('Setting custom urls.');
     configs.urls = urls;
   }
-  
+
   return configs;
 };
 


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?
- Added `SPLIT_EVALUATOR_IP_ADDRESSES_ENABLED` flag to enable/disable ip and hostname when Impressions and Events are generated.

## How do we test the changes introduced in this PR?
- Generate Impression or Events and checks in admin console if ip has value or not.

## Extra Notes