### PR TITLE
[SDKS-6256] Allow to use AUTH_TOKEN and API_KEY without ENVIRONMENTS env var

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,10 @@
 2.1.1 (XXX XX, 2022)
   - Updated SDK version to v10.22.0 which is the latest to the date.
-  - Added cors
+  - Added new env variable to enable cors
   - Added Multi environment support
   - Added new env variables:
     - SPLIT_EVALUATOR_ENVIRONMENTS
+    - SPLIT_EVALUATOR_ENABLE_CORS
 
 2.1.0 (Jul 15, 2022)
  - Added support for attribute values to be sent as JSON in a POST version of the get treatment endpoints, to avoid query param limitations.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
+2.1.1 (XXX XX, 2022)
+  - Updated SDK version to v10.22.0 which is the latest to the date.
+  - Added cors
+  - Added Multi environment support
+  - Added new env variables:
+    - SPLIT_EVALUATOR_ENVIRONMENTS
+
 2.1.0 (Jul 15, 2022)
  - Added support for attribute values to be sent as JSON in a POST version of the get treatment endpoints, to avoid query param limitations.
- - Updated the SDK version to 10.20.0 which is the latest to the date. 
+ - Updated the SDK version to 10.20.0 which is the latest to the date.
  - Updated npm dependencies for vulnerability fixes.
  - Updated base image to node:16.16.0-alpine3.16
 

--- a/__tests__/cors.test.js
+++ b/__tests__/cors.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+
+describe('CORS ', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('', async () => {
+    process.env.SPLIT_EVALUATOR_ENABLE_CORS = true;
+    const app = require('../app');
+    const { headers } = await request(app).get('/');
+    expect(headers['access-control-allow-origin']).toEqual('*');
+  });
+
+  test('default', async () => {
+    delete process.env.SPLIT_EVALUATOR_ENABLE_CORS;
+    const app = require('../app');
+    const { headers } = await request(app).get('/');
+    expect(headers['access-control-allow-origin']).toEqual(undefined);
+  });
+
+});

--- a/admin/__tests__/machine.test.js
+++ b/admin/__tests__/machine.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const os = require('os');
 const ip = require('@splitsoftware/splitio/lib/utils/ip');
 const request = require('supertest');

--- a/admin/__tests__/ping.test.js
+++ b/admin/__tests__/ping.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError } = require('../../utils/testWrapper/index');

--- a/admin/__tests__/uptime.test.js
+++ b/admin/__tests__/uptime.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError } = require('../../utils/testWrapper/index');

--- a/admin/__tests__/version.test.js
+++ b/admin/__tests__/version.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const utils = require('../../utils/utils');
 const environmentManager = require('../../environmentManager').getInstance();
 

--- a/app.js
+++ b/app.js
@@ -18,6 +18,10 @@ const adminRouter = require('./admin/admin.router');
 // Utils
 const utils = require('./utils/utils');
 
+// Cors
+var cors = require('cors');
+app.use(cors());
+
 app.use(morgan('tiny'));
 
 // OPENAPI 3.0 Definition

--- a/app.js
+++ b/app.js
@@ -30,10 +30,10 @@ app.use(morgan('tiny'));
 // Grabs yaml
 const openApiDefinition = YAML.load(fs.readFileSync('./openapi/openapi.yaml').toString());
 // Informs warn and remove security tag
-if (!environmentManager.getAuthTokens().length) {
+if (!environmentManager.requireAuth) {
   delete openApiDefinition.security;
   delete openApiDefinition.components.securitySchemes;
-  console[console.warn ? 'warn' : 'log']('External API key not provided. If you want a security filter use the SPLIT_EVALUATOR_AUTH_TOKEN environment variable as explained as explained in our documentation.');
+  console[console.warn ? 'warn' : 'log']('External API key not provided. If you want a security filter use the SPLIT_EVALUATOR_AUTH_TOKEN environment variable as explained in our documentation.');
 }
 // Updates version to current one
 openApiDefinition.info.version = utils.getVersion();

--- a/app.js
+++ b/app.js
@@ -17,10 +17,12 @@ const adminRouter = require('./admin/admin.router');
 
 // Utils
 const utils = require('./utils/utils');
-
 // Cors
-var cors = require('cors');
-app.use(cors());
+if (process.env.SPLIT_EVALUATOR_ENABLE_CORS === 'true') {
+  console[console.warn ? 'warn' : 'log']('Cors enabled');
+  const cors = require('cors');
+  app.use(cors());
+}
 
 app.use(morgan('tiny'));
 

--- a/client/__tests__/allTreatments.test.js
+++ b/client/__tests__/allTreatments.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkAllTreatments, getLongKey } = require('../../utils/testWrapper');

--- a/client/__tests__/allTreatmentsWithConfig.test.js
+++ b/client/__tests__/allTreatmentsWithConfig.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkAllTreatments, getLongKey } = require('../../utils/testWrapper');

--- a/client/__tests__/treatmentWithConfig.test.js
+++ b/client/__tests__/treatmentWithConfig.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOk, getLongKey } = require('../../utils/testWrapper');

--- a/client/__tests__/treatments.test.js
+++ b/client/__tests__/treatments.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkMultipleResults, getLongKey } = require('../../utils/testWrapper');

--- a/client/__tests__/treatmentsWithConfig.test.js
+++ b/client/__tests__/treatmentsWithConfig.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkMultipleResults, getLongKey } = require('../../utils/testWrapper');

--- a/environmentManager/__tests__/environment.test.js
+++ b/environmentManager/__tests__/environment.test.js
@@ -342,3 +342,43 @@ describe('environmentManager - client endpoints',  () => {
   });
 
 });
+
+describe('environmentManager - empty environments',  () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+  describe('empty AUTH_TOKEN - authorization not required',  () => {
+
+    test('[GET] should be 200 if authorization is not sent', async () => {
+      delete process.env.SPLIT_EVALUATOR_ENVIRONMENTS;
+      process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
+      const app = require('../../app');
+
+      // fetch without authorization
+      const response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment');
+      expect(response.body.treatment).toEqual('on');
+    });
+  });
+
+  describe('empty AUTH_TOKEN - authorization required',  () => {
+
+    test('[GET] should be 401 if authorization is not sent', async () => {
+      delete process.env.SPLIT_EVALUATOR_ENVIRONMENTS;
+      process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
+      process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'key_green';
+      const app = require('../../app');
+
+      // fetch without authorization - unauthorized error expected
+      let response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment');
+      expect(response.body).toEqual({'error': 'Unauthorized'});
+
+      // fetch with authorization
+      response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment')
+        .set('Authorization', 'key_green');
+      expect(response.body.treatment).toEqual('on');
+    });
+  });
+});

--- a/listener/__tests__/listener.test.js
+++ b/listener/__tests__/listener.test.js
@@ -1,5 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
 process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT = 'http://localhost:7546';
 
 const http = require('http');

--- a/listener/__tests__/queue.test.js
+++ b/listener/__tests__/queue.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const ImpressionQueue = require('../queue');
 
 const impression1 = {

--- a/listener/manager.js
+++ b/listener/manager.js
@@ -74,6 +74,7 @@ const ImpressionManagerFactory = (function(){
       return instance;
     },
     async destroy() {
+      if (!instance) return;
       await instance.destroy();
       instance = undefined;
     },

--- a/manager/__tests__/split.test.js
+++ b/manager/__tests__/split.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining } = require('../../utils/testWrapper');

--- a/manager/__tests__/splitNames.test.js
+++ b/manager/__tests__/splitNames.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError } = require('../../utils/testWrapper');

--- a/manager/__tests__/splits.test.js
+++ b/manager/__tests__/splits.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError } = require('../../utils/testWrapper');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@splitsoftware/splitio": "10.22.0",
         "config": "1.25.1",
+        "cors": "^2.8.5",
         "express": "^4.17.1",
         "morgan": "^1.9.1",
         "npm": "^8.13.2",
@@ -3858,6 +3859,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -11115,6 +11128,14 @@
         "node": "*"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -16802,6 +16823,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -22101,6 +22131,11 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@splitsoftware/splitio": "10.22.0",
     "config": "1.25.1",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "morgan": "^1.9.1",
     "npm": "^8.13.2",


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?
Enable AUTH_TOKEN and API_KEY env vars to be used when ENVIRONMENTS is not setted
if AUTH_TOKEN is undefined, then authorization header is not required
Removed unused environment var set on tests

## How do we test the changes introduced in this PR?
Added unit tests

## Extra Notes
