### PR TITLE
[SDKS-6256] Allow to use AUTH_TOKEN and API_KEY without ENVIRONMENTS env var

### DIFF
--- a/admin/__tests__/machine.test.js
+++ b/admin/__tests__/machine.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const os = require('os');
 const ip = require('@splitsoftware/splitio/lib/utils/ip');
 const request = require('supertest');

--- a/admin/__tests__/ping.test.js
+++ b/admin/__tests__/ping.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError } = require('../../utils/testWrapper/index');

--- a/admin/__tests__/uptime.test.js
+++ b/admin/__tests__/uptime.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError } = require('../../utils/testWrapper/index');

--- a/admin/__tests__/version.test.js
+++ b/admin/__tests__/version.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const utils = require('../../utils/utils');
 const environmentManager = require('../../environmentManager').getInstance();
 

--- a/app.js
+++ b/app.js
@@ -24,10 +24,10 @@ app.use(morgan('tiny'));
 // Grabs yaml
 const openApiDefinition = YAML.load(fs.readFileSync('./openapi/openapi.yaml').toString());
 // Informs warn and remove security tag
-if (!environmentManager.getAuthTokens().length) {
+if (!environmentManager.requireAuth) {
   delete openApiDefinition.security;
   delete openApiDefinition.components.securitySchemes;
-  console[console.warn ? 'warn' : 'log']('External API key not provided. If you want a security filter use the SPLIT_EVALUATOR_AUTH_TOKEN environment variable as explained as explained in our documentation.');
+  console[console.warn ? 'warn' : 'log']('External API key not provided. If you want a security filter use the SPLIT_EVALUATOR_AUTH_TOKEN environment variable as explained in our documentation.');
 }
 // Updates version to current one
 openApiDefinition.info.version = utils.getVersion();

--- a/client/__tests__/allTreatments.test.js
+++ b/client/__tests__/allTreatments.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkAllTreatments, getLongKey } = require('../../utils/testWrapper');

--- a/client/__tests__/allTreatmentsWithConfig.test.js
+++ b/client/__tests__/allTreatmentsWithConfig.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkAllTreatments, getLongKey } = require('../../utils/testWrapper');

--- a/client/__tests__/treatmentWithConfig.test.js
+++ b/client/__tests__/treatmentWithConfig.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOk, getLongKey } = require('../../utils/testWrapper');

--- a/client/__tests__/treatments.test.js
+++ b/client/__tests__/treatments.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkMultipleResults, getLongKey } = require('../../utils/testWrapper');

--- a/client/__tests__/treatmentsWithConfig.test.js
+++ b/client/__tests__/treatmentsWithConfig.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkMultipleResults, getLongKey } = require('../../utils/testWrapper');

--- a/environmentManager/__tests__/environment.test.js
+++ b/environmentManager/__tests__/environment.test.js
@@ -342,3 +342,43 @@ describe('environmentManager - client endpoints',  () => {
   });
 
 });
+
+describe('environmentManager - empty environments',  () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+  describe('empty AUTH_TOKEN - authorization not required',  () => {
+
+    test('[GET] should be 200 if authorization is not sent', async () => {
+      delete process.env.SPLIT_EVALUATOR_ENVIRONMENTS;
+      process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
+      const app = require('../../app');
+
+      // fetch without authorization
+      const response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment');
+      expect(response.body.treatment).toEqual('on');
+    });
+  });
+
+  describe('empty AUTH_TOKEN - authorization required',  () => {
+
+    test('[GET] should be 401 if authorization is not sent', async () => {
+      delete process.env.SPLIT_EVALUATOR_ENVIRONMENTS;
+      process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
+      process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'key_green';
+      const app = require('../../app');
+
+      // fetch without authorization - unauthorized error expected
+      let response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment');
+      expect(response.body).toEqual({'error': 'Unauthorized'});
+
+      // fetch with authorization
+      response = await request(app)
+        .get('/client/get-treatment?key=test&split-name=my-experiment')
+        .set('Authorization', 'key_green');
+      expect(response.body.treatment).toEqual('on');
+    });
+  });
+});

--- a/listener/__tests__/listener.test.js
+++ b/listener/__tests__/listener.test.js
@@ -1,5 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
 process.env.SPLIT_EVALUATOR_IMPRESSION_LISTENER_ENDPOINT = 'http://localhost:7546';
 
 const http = require('http');

--- a/listener/__tests__/queue.test.js
+++ b/listener/__tests__/queue.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const ImpressionQueue = require('../queue');
 
 const impression1 = {

--- a/manager/__tests__/split.test.js
+++ b/manager/__tests__/split.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining } = require('../../utils/testWrapper');

--- a/manager/__tests__/splitNames.test.js
+++ b/manager/__tests__/splitNames.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError } = require('../../utils/testWrapper');

--- a/manager/__tests__/splits.test.js
+++ b/manager/__tests__/splits.test.js
@@ -1,6 +1,3 @@
-process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'test';
-process.env.SPLIT_EVALUATOR_API_KEY = 'localhost';
-
 const request = require('supertest');
 const app = require('../../app');
 const { expectError } = require('../../utils/testWrapper');


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?
Enable AUTH_TOKEN and API_KEY env vars to be used when ENVIRONMENTS is not setted
if AUTH_TOKEN is undefined, then authorization header is not required
Removed unused environment var set on tests

## How do we test the changes introduced in this PR?
Added unit tests

## Extra Notes
