### PR TITLE
[SDKS-6474] Initialize evaluator if there is at least one client ready

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -8,8 +8,6 @@ jest.mock('../sdk', () => ({
     const { __dirname } = require('../utils/utils');
     const path = require('path');
 
-    const timeOut = settings.core.authorizationKey === 'timeout'
-
     // Clients are configured in localhost mode if there is a features file maped to the authorizationKey value in mocksMap
     const mocksMap = {
       'localhost': '/parserConfigs/split.yml',

--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -1,31 +1,50 @@
 // Environments for testing
 process.env.SPLIT_EVALUATOR_ENVIRONMENTS='[{"API_KEY":"localhost","AUTH_TOKEN":"test"},{"API_KEY":"apikey1","AUTH_TOKEN":"key_blue"},{"API_KEY":"apikey2","AUTH_TOKEN":"key_red"}]'
 
-// Before all tests, sdk module is mocked to create a wrapper where a diifferent yaml file is assigned to each environment
+// Before all tests, sdk module is mocked to create a wrapper where a different yaml file is assigned to each environment
 // sdk factory mock to set a different yaml for each apikey and localhost mode
 jest.mock('../sdk', () => ({
   getSplitFactory: jest.fn((settings) => {
     const { __dirname } = require('../utils/utils');
     const path = require('path');
 
+    const timeOut = settings.core.authorizationKey === 'timeout'
 
+    // Clients are configured in localhost mode if there is a features file maped to the authorizationKey value in mocksMap
     const mocksMap = {
       'localhost': '/parserConfigs/split.yml',
       'apikey1': '/split1.yml',
       'apikey2': '/split2.yml',
     };
 
+    let features = '';
+    let authorizationKey = settings.core.authorizationKey;
+
+    // if authorizationKey has a feature file maped in mocksMap
+    if (mocksMap[settings.core.authorizationKey]) {
+      // Set feature file
+      features = path.join(__dirname, mocksMap[settings.core.authorizationKey]);
+      // Set mode to localhost
+      authorizationKey = 'localhost'
+    };
+
     const configForMock = {
       ...settings,
       core: {
         ...settings.core,
-        authorizationKey: 'localhost',
+        authorizationKey: authorizationKey,
       },
-      features: path.join(__dirname, mocksMap[settings.core.authorizationKey]),
+      startup: {
+        readyTimeout: 1,
+      },
+      features: features,
       scheduler: {
         ...settings.scheduler,
-        offlineRefreshRate: 0,
+        featuresRefreshRate: 1,
+        segmentsRefreshRate: 1,
+        impressionsRefreshRate: 30000
       },
+      streamingEnabled: false
     };
 
     let sdk = jest.requireActual('../sdk');

--- a/environmentManager/__tests__/clientReadines.test.js
+++ b/environmentManager/__tests__/clientReadines.test.js
@@ -1,0 +1,108 @@
+// Environment configurations
+const threeReady = JSON.stringify([
+  { API_KEY: 'localhost', AUTH_TOKEN: 'ready1' },
+  { API_KEY: 'apikey1', AUTH_TOKEN: 'ready2' },
+  { API_KEY: 'apikey2', AUTH_TOKEN: 'ready3' }
+]);
+
+const twoReadyOneTimedOut = JSON.stringify([
+  { API_KEY: 'localhost', AUTH_TOKEN: 'ready1' },
+  { API_KEY: 'apikey1', AUTH_TOKEN: 'ready2' },
+  { API_KEY: 'timeout', AUTH_TOKEN: 'timedOut' }
+]);
+
+const oneReadyTwoTimedOut = JSON.stringify([
+  { API_KEY: 'localhost', AUTH_TOKEN: 'ready1' },
+  { API_KEY: 'timeout', AUTH_TOKEN: 'timedOut1' },
+  { API_KEY: 'timeout', AUTH_TOKEN: 'timedOut2' }
+]);
+
+const threeTimedOut = JSON.stringify([
+  { API_KEY: 'timeout', AUTH_TOKEN: 'timedOut1' },
+  { API_KEY: 'timeout', AUTH_TOKEN: 'timedOut2' },
+  { API_KEY: 'timeout', AUTH_TOKEN: 'timedOut3' }
+]);
+
+// Mock fetch to response 404 to any http request
+jest.mock('node-fetch', () => {
+  return jest.fn().mockImplementation(() => {
+    return Promise.reject({ response: { status: 404, response: 'response'}});
+  });
+});
+
+// Test environmentManager client readiness
+describe('environmentManager',  () => {
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    // Unmock fetch
+    jest.unmock('node-fetch');
+  });
+
+  describe('clientReadiness',  () => {
+
+    // If at least one client is ready, environmentManager.ready() should return true to initialize evaluator
+    test('Three clients ready', (done) => {
+      delete process.env.SPLIT_EVALUATOR_ENVIRONMENTS;
+      process.env.SPLIT_EVALUATOR_ENVIRONMENTS=threeReady;
+      const environmentManagerFactory = require('../');
+      const environmentManager = environmentManagerFactory.getInstance();
+      environmentManager.ready().then(ready => {
+        expect(ready).toBe(true);
+        expect(environmentManager.getClient('ready1').isClientReady).toBe(true);
+        expect(environmentManager.getClient('ready2').isClientReady).toBe(true);
+        expect(environmentManager.getClient('ready3').isClientReady).toBe(true);
+        done();
+      });
+    });
+
+    // If at least one client is ready, environmentManager.ready() should return true to initialize evaluator
+    test('Two clients ready, one timed out', (done) => {
+      delete process.env.SPLIT_EVALUATOR_ENVIRONMENTS;
+      process.env.SPLIT_EVALUATOR_ENVIRONMENTS=twoReadyOneTimedOut;
+      const environmentManagerFactory = require('../');
+      const environmentManager = environmentManagerFactory.getInstance();
+      environmentManager.ready().then(ready => {
+        expect(ready).toBe(true);
+        expect(environmentManager.getClient('ready1').isClientReady).toBe(true);
+        expect(environmentManager.getClient('ready2').isClientReady).toBe(true);
+        expect(environmentManager.getClient('timedOut').isClientReady).toBe(false);
+        done();
+      });
+    });
+
+    // If at least one client is ready, environmentManager.ready() should return true to initialize evaluator
+    test('One client ready, two timed out', (done) => {
+      delete process.env.SPLIT_EVALUATOR_ENVIRONMENTS;
+      process.env.SPLIT_EVALUATOR_ENVIRONMENTS=oneReadyTwoTimedOut;
+      const environmentManagerFactory = require('../');
+      const environmentManager = environmentManagerFactory.getInstance();
+      environmentManager.ready().then(ready => {
+        expect(ready).toBe(true);
+        expect(environmentManager.getClient('ready1').isClientReady).toBe(true);
+        expect(environmentManager.getClient('timedOut1').isClientReady).toBe(false);
+        expect(environmentManager.getClient('timedOut2').isClientReady).toBe(false);
+        done();
+      });
+    });
+
+    // If every client timed out, environmentManager.ready() should return false to avoid evaluator initialization
+    test('Three clients timed out', (done) => {
+      delete process.env.SPLIT_EVALUATOR_ENVIRONMENTS;
+      process.env.SPLIT_EVALUATOR_ENVIRONMENTS=threeTimedOut;
+      const environmentManagerFactory = require('../');
+      const environmentManager = environmentManagerFactory.getInstance();
+      environmentManager.ready().then(ready => {
+        expect(ready).toBe(false);
+        expect(environmentManager.getClient('timedOut1').isClientReady).toBe(false);
+        expect(environmentManager.getClient('timedOut2').isClientReady).toBe(false);
+        expect(environmentManager.getClient('timedOut3').isClientReady).toBe(false);
+        done();
+      });
+    });
+  });
+});

--- a/environmentManager/index.js
+++ b/environmentManager/index.js
@@ -6,24 +6,32 @@ const SPLIT_EVALUATOR_AUTH_TOKEN = 'SPLIT_EVALUATOR_AUTH_TOKEN';
 const SPLIT_EVALUATOR_API_KEY = 'SPLIT_EVALUATOR_API_KEY';
 
 const EnvironmentManagerFactory = (function(){
+  /**
+   * EnvironmentManager singleton
+   */
   class EnvironmentManager {
 
     constructor() {
-
-      // In environments are the apiKey, factory an clientReadiness status related to an authToken
+      // Contains every environment related to an authToken with its apiKey, factory and clientReadiness status
       this._environments = {};
 
       // Ready promises for each client in environment manager
       this._readyPromises = [];
 
+      // Used to know if there is any client ready and evaluator should start
+      this._clientsReady = false;
+
+      // Defines if openApi security tag should be added
       this.requireAuth = true;
 
       this._initializeEnvironments();
     }
 
     _initializeEnvironments(){
+      // If environments envVar is not defined, it creates an environment with auth_token and api_key envVars
       if (!process.env.SPLIT_EVALUATOR_ENVIRONMENTS) {
         const AUTH_TOKEN = process.env.SPLIT_EVALUATOR_AUTH_TOKEN;
+        // If auth_token envVar is not defined, means that openapi security tag should not be added
         if (!AUTH_TOKEN) {
           this.requireAuth = false;
           process.env.SPLIT_EVALUATOR_AUTH_TOKEN = 'splitToken';
@@ -51,6 +59,7 @@ const EnvironmentManagerFactory = (function(){
           throwError(`There are two or more environments with the same authToken '${authToken}' `);
         }
 
+        // Creates an environment for authToken
         this._environments[authToken] = {
           apiKey: apiKey,
           factory: getSplitFactory(settings),
@@ -59,21 +68,27 @@ const EnvironmentManagerFactory = (function(){
 
         const client = this.getFactory(authToken).client();
         this._clientReadiness(client, apiKey);
-
-
       });
-      this.ready();
     }
 
     _clientReadiness(client, apiKey){
+      // Add client ready promise to array to wait asynchronously to be resolved
       this._readyPromises.push(client.ready());
+      // Encode apiKey to log it without exposing it (like ####1234)
       const encodedApiKey = apiKey.replace(/.(?=.{4,}$)/g, '#');
+      // Handle client ready
       client.on(client.Event.SDK_READY, () => {
         console.info(`Client ready for api key ${encodedApiKey}`);
+        this._clientsReady = true;
         client.isClientReady = true;
       });
+      // Handle client timed out
       client.on(client.Event.SDK_READY_TIMED_OUT, () => {
-        throwError(`Client timed out for api key ${encodedApiKey}`);
+        console.info(`Client timed out for api key ${encodedApiKey}`);
+        client.isClientReady = false;
+        client.destroy().then(() => {
+          console.info('Timed out client destroyed');
+        });
       });
     }
 
@@ -103,9 +118,11 @@ const EnvironmentManagerFactory = (function(){
       return Object.keys(this._environments);
     }
 
+    // Awaits for every client ready promise
     async ready() {
-      return Promise.allSettled(this._readyPromises).then(() => {
-        this._clientsReady = true;
+      return Promise.allSettled(this._readyPromises).then((environmentsStatus) => {
+        this._clientsReady = environmentsStatus.some(environment => environment.status === 'fulfilled');
+        return this._clientsReady;
       });
     }
 
@@ -128,6 +145,7 @@ const EnvironmentManagerFactory = (function(){
 
   let instance;
 
+  // Singleton handle strategy
   return {
     hasInstance() {
       return !instance ? false : true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "supertest": "^6.3.1"
       },
       "engines": {
-        "node": "18"
+        "node": ">=16"
       }
     },
     "node_modules/@ably/bloomit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "supertest": "^6.3.1"
       },
       "engines": {
-        "node": "16"
+        "node": "18"
       }
     },
     "node_modules/@ably/bloomit": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "swagger-ui-express": "^4.3.0"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "swagger-ui-express": "^4.3.0"
   },
   "engines": {
-    "node": "18"
+    "node": ">=16"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/server.js
+++ b/server.js
@@ -11,12 +11,22 @@ const PORT = process.env.SPLIT_EVALUATOR_SERVER_PORT || 7548;
 let server;
 // Only available for in memory settings.
 if (config.get('blockUntilReady')) {
-  environmentManager.ready().then(spinUpServer);
+  environmentManager.ready().then(ready => spinUpServer(ready));
 } else {
-  spinUpServer();
+  environmentManager.ready().then(ready => {
+    if (!ready) {
+      console.log('There is no client ready, initialization aborted');
+      process.exit(0);
+    }
+  });
+  spinUpServer(true);
 }
 
-function spinUpServer() {
+function spinUpServer(splitClientsReady) {
+  if (!splitClientsReady) {
+    console.log('There is no client ready, initialization aborted');
+    return;
+  }
   server = app.listen(PORT, '0.0.0.0', function () {
     utils.uptime('init');
     console.log('Server is Up and Running at Port : ' + PORT);


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?
Update environment manager and evaluator initialization to allow evaluator to start if there is at least one environment with a ready client.
If there are environments with clients that timed out, the evaluator warns it and destroys those clients.
If every environment's clients timed out, the evaluator warns and destroy every client and should  not initialize

## How do we test the changes introduced in this PR?
Added Unit tests

## Extra Notes
