### PR TITLE
Add get treatments by flag set api

### DIFF
--- a/client/__tests__/treatmentsByFlagSet.test.js
+++ b/client/__tests__/treatmentsByFlagSet.test.js
@@ -1,19 +1,21 @@
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkMultipleResults, getLongKey } = require('../../utils/testWrapper');
-const { NULL_FLAG_SETS, EMPTY_FLAG_SETS } = require('../../utils/constants');
-const { expectedGreenResultsWithConfig, expectedPurpleResultsWithConfig, expectedPinkResultsWithConfig } = require('../../utils/mocks');
+const { NULL_FLAG_SET, EMPTY_FLAG_SET, MAYBE_FLAG_SETS } = require('../../utils/constants');
+const { expectedGreenResults, expectedPurpleResults } = require('../../utils/mocks');
 
 jest.mock('node-fetch', () => {
   return jest.fn().mockImplementation((url) => {
+
     const sdkUrl = 'https://sdk.test.io/api/splitChanges?since=-1';
     const splitChange2 = require('../../utils/mocks/splitchanges.since.-1.till.1602796638344.json');
-    if (url.startsWith(sdkUrl)) return Promise.resolve({ status: 200, json: () => (splitChange2), ok: true});
+    if (url.startsWith(sdkUrl)) return Promise.resolve({ status: 200, json: () => (splitChange2), ok: true });
+
     return Promise.resolve({ status: 200, json: () => ({}), ok: true });
   });
 });
 
-describe('get-treatments-with-config-by-sets', () => {
+describe('get-treatments-by-set', () => {
 
   beforeEach(() => {
     jest.resetModules();
@@ -28,26 +30,27 @@ describe('get-treatments-with-config-by-sets', () => {
   // Testing authorization
   test('should be 401 if auth is not passed', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=my-experiment');
+      .get('/client/get-treatments-by-set?key=test&flag-set=my-experiment');
     expectError(response, 401, 'Unauthorized');
     done();
   });
 
   test('should be 401 if auth does not match', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=my-experiment')
+      .get('/client/get-treatments-by-set?key=test&flag-set=my-experiment')
       .set('Authorization', 'invalid');
     expectError(response, 401, 'Unauthorized');
     done();
   });
 
-  // Testing Input Validation
+  // Testing Input Validation.
+  // The following tests are going to check null parameters, wrong types or lengths.
   test('should be 400 if key is not passed', async (done) => {
     const expected = [
       'you passed a null or undefined key, key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?flag-sets=test')
+      .get('/client/get-treatments-by-set?flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -58,7 +61,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed an empty string, key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=&flag-sets=test')
+      .get('/client/get-treatments-by-set?key=&flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -69,7 +72,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed an empty string, key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=     &flag-sets=test')
+      .get('/client/get-treatments-by-set?key=     &flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -79,9 +82,12 @@ describe('get-treatments-with-config-by-sets', () => {
     const expected = [
       'key too long, key must be 250 characters or less.'
     ];
-    const key = getLongKey();
+    let key = '';
+    for (let i = 0; i <=250; i++) {
+      key += 'a';
+    }
     const response = await request(app)
-      .get(`/client/get-treatments-with-config-by-sets?key=${key}&flag-sets=test`)
+      .get(`/client/get-treatments-by-set?key=${key}&flag-set=test`)
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -92,7 +98,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed an empty string, bucketing-key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key&bucketing-key=&flag-sets=test')
+      .get('/client/get-treatments-by-set?key=key&bucketing-key=&flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -103,7 +109,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed an empty string, bucketing-key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key&bucketing-key=    &flag-sets=test')
+      .get('/client/get-treatments-by-set?key=key&bucketing-key=    &flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -113,54 +119,57 @@ describe('get-treatments-with-config-by-sets', () => {
     const expected = [
       'bucketing-key too long, bucketing-key must be 250 characters or less.'
     ];
-    const key = getLongKey();
+    let key = '';
+    for (let i = 0; i <=250; i++) {
+      key += 'a';
+    }
     const response = await request(app)
-      .get(`/client/get-treatments-with-config-by-sets?key=key&bucketing-key=${key}&flag-sets=test`)
+      .get(`/client/get-treatments-by-set?key=key&bucketing-key=${key}&flag-set=test`)
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
   });
 
-  test('should be 400 if flag-sets is not passed', async (done) => {
+  test('should be 400 if flag-set is not passed', async (done) => {
     const expected = [
-      NULL_FLAG_SETS
+      NULL_FLAG_SET
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test')
+      .get('/client/get-treatments-by-set?key=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
   });
 
-  test('should be 400 if flag-sets is empty', async (done) => {
+  test('should be 400 if flag-set is empty', async (done) => {
     const expected = [
-      EMPTY_FLAG_SETS
+      EMPTY_FLAG_SET
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=')
+      .get('/client/get-treatments-by-set?key=test&flag-set=')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
   });
 
-  test('should be 400 if flag-sets is empty trimmed', async (done) => {
+  test('should be 400 if flag-set is empty trimmed', async (done) => {
     const expected = [
-      EMPTY_FLAG_SETS
+      EMPTY_FLAG_SET
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=    ')
+      .get('/client/get-treatments-by-set?key=test&flag-set=    ')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
   });
 
-  test('should be 400 if there are errors in key and flag-sets', async (done) => {
+  test('should be 400 if there are errors in key and flag-set', async (done) => {
     const expected = [
       'you passed an empty string, key must be a non-empty string.',
-      EMPTY_FLAG_SETS
+      EMPTY_FLAG_SET
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=&flag-sets=    ')
+      .get('/client/get-treatments-by-set?key=&flag-set=    ')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -171,7 +180,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'attributes must be a plain object.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=my-experiment&attributes=lalala')
+      .get('/client/get-treatments-by-set?key=test&flag-set=my-experiment&attributes=lalala')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -180,11 +189,11 @@ describe('get-treatments-with-config-by-sets', () => {
   test('should be 400 if there are multiple errors', async (done) => {
     const expected = [
       'you passed an empty string, key must be a non-empty string.',
-      EMPTY_FLAG_SETS,
+      EMPTY_FLAG_SET,
       'attributes must be a plain object.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=     &flag-sets=&attributes="lalala"')
+      .get('/client/get-treatments-by-set?key=     &flag-set=&attributes="lalala"')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -193,13 +202,48 @@ describe('get-treatments-with-config-by-sets', () => {
   test('should be 400 if there are multiple errors in every input', async (done) => {
     const expected = [
       'you passed an empty string, key must be a non-empty string.',
-      EMPTY_FLAG_SETS,
+      EMPTY_FLAG_SET,
       'attributes must be a plain object.',
       'bucketing-key too long, bucketing-key must be 250 characters or less.'
     ];
     const key = getLongKey();
     const response = await request(app)
-      .get(`/client/get-treatments-with-config-by-sets?bucketing-key=${key}&key=     &flag-sets=&attributes="lalala"`)
+      .get(`/client/get-treatments-by-set?bucketing-key=${key}&key=     &flag-set=&attributes="lalala"`)
+      .set('Authorization', 'key_green');
+    expectErrorContaining(response, 400, expected);
+    done();
+  });
+
+  test('should be 400 if attributes is an invalid json (POST)', async (done) => {
+    const response = await request(app)
+      .post('/client/get-treatments-by-set?key=test&flag-set=my-experiment')
+      .set('Content-Type', 'application/json')
+      // eslint-disable-next-line no-useless-escape
+      .send('\|\\\"/regex/i') // Syntax error parsing the JSON.
+      .set('Authorization', 'key_green');
+    expectError(response, 400);
+    expect(response.body.error.type).toBe('entity.parse.failed'); // validate the error
+    done();
+  });
+
+  test('should be 400 with multiple evaluation', async (done) => {
+    const expected = [
+      MAYBE_FLAG_SETS
+    ];
+    const response = await request(app)
+      .get('/client/get-treatments-by-set?key=key_green&flag-set=set_green,set_purple')
+      .set('Authorization', 'key_green');
+    expectErrorContaining(response, 400, expected);
+    done();
+  });
+
+  test('should be 400 with multiple evaluation (POST)', async (done) => {
+    const expected = [
+      MAYBE_FLAG_SETS
+    ];
+    const response = await request(app)
+      .post('/client/get-treatments-by-set?key=key_green&flag-set=set_green,set_purple')
+      .set('Content-Type', 'application/json')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -207,70 +251,66 @@ describe('get-treatments-with-config-by-sets', () => {
 
   test('should be 200 if is valid attributes (GET)', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green&attributes={"test":"test"}')
+      .get('/client/get-treatments-by-set?key=key_green&flag-set=set_green&attributes={"test":"test"}')
       .set('Authorization', 'key_green');
-    expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
+    expectOkMultipleResults(response, 200, expectedGreenResults, 3);
     done();
   });
 
   test('should be 200 when attributes is null (GET)', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green')
+      .get('/client/get-treatments-by-set?key=key_green&flag-set=set_green')
       .set('Authorization', 'key_green');
-    expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
+    expectOkMultipleResults(response, 200, expectedGreenResults, 3);
     done();
   });
 
   test('should be 200 if is valid attributes (POST)', async (done) => {
     const response = await request(app)
-      .post('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green')
-      .send({attributes: { test:'test' }})
-      .set('Authorization', 'key_green');
-    expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
+      .post('/client/get-treatments-by-set?key=key_green&flag-set=set_green')
+      .set('Authorization', 'key_green')
+      .send({
+        attributes: {test:'test'},
+      });
+    expectOkMultipleResults(response, 200, expectedGreenResults, 3);
     done();
   });
 
-  test('should be 200 if is valid attributes stringified (POST)', async (done) => {
+  test('should be 200 if is valid attributes as string (POST)', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green&attributes={"test":"test"}')
-      .send(JSON.stringify({attributes: { test:'test' }}))
+      .post('/client/get-treatments-by-set?key=key_green&flag-set=set_green')
+      .send(JSON.stringify({
+        attributes: {test:'test'},
+      }))
       .set('Authorization', 'key_green');
-    expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
+    expectOkMultipleResults(response, 200, expectedGreenResults, 3);
     done();
   });
 
-  test('should be 200 when attributes is null (POST)', async (done) => {
+  test('should be 200 if attributes is null (POST)', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green')
+      .post('/client/get-treatments-by-set?key=key_green&flag-set=set_green')
       .send({
         attributes: null,
       })
       .set('Authorization', 'key_green');
-    expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
+    expectOkMultipleResults(response, 200, expectedGreenResults, 3);
     done();
   });
 
-  test('should be 200 with multiple evaluation but evualuate configured flag sets', async (done) => {
+  test('should be 200 and return an empty evaluation for not configured sets', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green,set_purple,nonexistant-experiment')
+      .get('/client/get-treatments-by-set?key=key_purple&flag-set=set_purple')
       .set('Authorization', 'key_green');
-    expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
+    expectOkMultipleResults(response, 200, [], 0);
     done();
   });
 
-  test('should be 200 with multiple evaluation but evualuate configured flag sets', async (done) => {
+  test('should be 200 for configured flag sets', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_purple&flag-sets=set_green,set_purple,nonexistant-experiment')
-      .set('Authorization', 'key_purple');
-    expectOkMultipleResults(response, 200, expectedPurpleResultsWithConfig, 3);
-    done();
-  });
-
-  test('should be 200 with multiple evaluation but evualuate configured flag sets', async (done) => {
-    const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_purple&flag-sets=set_green,set_purple,nonexistant-experiment')
+      .get('/client/get-treatments-by-set?key=key_pink&flag-set=set_purple')
       .set('Authorization', 'key_pink');
-    expectOkMultipleResults(response, 200, expectedPinkResultsWithConfig, 5);
+    expectOkMultipleResults(response, 200, expectedPurpleResults, 3);
     done();
   });
 });

--- a/client/__tests__/treatmentsByFlagSets.test.js
+++ b/client/__tests__/treatmentsByFlagSets.test.js
@@ -2,6 +2,7 @@ const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkMultipleResults, getLongKey } = require('../../utils/testWrapper');
 const { NULL_FLAG_SETS, EMPTY_FLAG_SETS } = require('../../utils/constants');
+const { expectedGreenResults, expectedPurpleResults, expectedPinkResults } = require('../../utils/mocks');
 
 jest.mock('node-fetch', () => {
   return jest.fn().mockImplementation((url) => {
@@ -215,7 +216,7 @@ describe('get-treatments-by-sets', () => {
 
   test('should be 400 if attributes is an invalid json (POST)', async (done) => {
     const response = await request(app)
-      .post('/client/get-treatments-by-sets?key=test&set-name=my-experiment')
+      .post('/client/get-treatments-by-sets?key=test&flag-sets=my-experiment')
       .set('Content-Type', 'application/json')
       // eslint-disable-next-line no-useless-escape
       .send('\|\\\"/regex/i') // Syntax error parsing the JSON.
@@ -224,50 +225,6 @@ describe('get-treatments-by-sets', () => {
     expect(response.body.error.type).toBe('entity.parse.failed'); // validate the error
     done();
   });
-
-  const expectedGreenResults = {
-    'test_green': {
-      treatment: 'on',
-    },
-    'test_color': {
-      treatment: 'on',
-    },
-    'test_green_config': {
-      treatment: 'on',
-      config: undefined,
-    },
-  };
-  const expectedPurpleResults = {
-    'test_purple': {
-      treatment: 'on',
-    },
-    'test_color': {
-      treatment: 'on',
-    },
-    'test_purple_config': {
-      treatment: 'on',
-      config: undefined,
-    },
-  };
-  const expectedPinkResults = {
-    'test_purple': {
-      treatment: 'on',
-    },
-    'test_green': {
-      treatment: 'on',
-    },
-    'test_color': {
-      treatment: 'on',
-    },
-    'test_purple_config': {
-      treatment: 'on',
-      config: undefined,
-    },
-    'test_green_config': {
-      treatment: 'on',
-      config: undefined,
-    },
-  };
 
   test('should be 200 if is valid attributes (GET)', async (done) => {
     const response = await request(app)

--- a/client/__tests__/treatmentsWithConfigByFlagSet.test.js
+++ b/client/__tests__/treatmentsWithConfigByFlagSet.test.js
@@ -1,8 +1,8 @@
 const request = require('supertest');
 const app = require('../../app');
 const { expectError, expectErrorContaining, expectOkMultipleResults, getLongKey } = require('../../utils/testWrapper');
-const { NULL_FLAG_SETS, EMPTY_FLAG_SETS } = require('../../utils/constants');
-const { expectedGreenResultsWithConfig, expectedPurpleResultsWithConfig, expectedPinkResultsWithConfig } = require('../../utils/mocks');
+const { NULL_FLAG_SET, EMPTY_FLAG_SET, MAYBE_FLAG_SETS } = require('../../utils/constants');
+const { expectedGreenResultsWithConfig, expectedPurpleResultsWithConfig } = require('../../utils/mocks');
 
 jest.mock('node-fetch', () => {
   return jest.fn().mockImplementation((url) => {
@@ -13,7 +13,7 @@ jest.mock('node-fetch', () => {
   });
 });
 
-describe('get-treatments-with-config-by-sets', () => {
+describe('get-treatments-with-config-by-set', () => {
 
   beforeEach(() => {
     jest.resetModules();
@@ -28,14 +28,14 @@ describe('get-treatments-with-config-by-sets', () => {
   // Testing authorization
   test('should be 401 if auth is not passed', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=my-experiment');
+      .get('/client/get-treatments-with-config-by-set?key=test&flag-set=my-experiment');
     expectError(response, 401, 'Unauthorized');
     done();
   });
 
   test('should be 401 if auth does not match', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=my-experiment')
+      .get('/client/get-treatments-with-config-by-set?key=test&flag-set=my-experiment')
       .set('Authorization', 'invalid');
     expectError(response, 401, 'Unauthorized');
     done();
@@ -47,7 +47,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed a null or undefined key, key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?flag-sets=test')
+      .get('/client/get-treatments-with-config-by-set?flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -58,7 +58,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed an empty string, key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=&flag-sets=test')
+      .get('/client/get-treatments-with-config-by-set?key=&flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -69,7 +69,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed an empty string, key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=     &flag-sets=test')
+      .get('/client/get-treatments-with-config-by-set?key=     &flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -81,7 +81,7 @@ describe('get-treatments-with-config-by-sets', () => {
     ];
     const key = getLongKey();
     const response = await request(app)
-      .get(`/client/get-treatments-with-config-by-sets?key=${key}&flag-sets=test`)
+      .get(`/client/get-treatments-with-config-by-set?key=${key}&flag-set=test`)
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -92,7 +92,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed an empty string, bucketing-key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key&bucketing-key=&flag-sets=test')
+      .get('/client/get-treatments-with-config-by-set?key=key&bucketing-key=&flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -103,7 +103,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'you passed an empty string, bucketing-key must be a non-empty string.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key&bucketing-key=    &flag-sets=test')
+      .get('/client/get-treatments-with-config-by-set?key=key&bucketing-key=    &flag-set=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -115,52 +115,52 @@ describe('get-treatments-with-config-by-sets', () => {
     ];
     const key = getLongKey();
     const response = await request(app)
-      .get(`/client/get-treatments-with-config-by-sets?key=key&bucketing-key=${key}&flag-sets=test`)
+      .get(`/client/get-treatments-with-config-by-set?key=key&bucketing-key=${key}&flag-set=test`)
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
   });
 
-  test('should be 400 if flag-sets is not passed', async (done) => {
+  test('should be 400 if flag-set is not passed', async (done) => {
     const expected = [
-      NULL_FLAG_SETS
+      NULL_FLAG_SET
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test')
+      .get('/client/get-treatments-with-config-by-set?key=test')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
   });
 
-  test('should be 400 if flag-sets is empty', async (done) => {
+  test('should be 400 if flag-set is empty', async (done) => {
     const expected = [
-      EMPTY_FLAG_SETS
+      EMPTY_FLAG_SET
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=')
+      .get('/client/get-treatments-with-config-by-set?key=test&flag-set=')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
   });
 
-  test('should be 400 if flag-sets is empty trimmed', async (done) => {
+  test('should be 400 if flag-set is empty trimmed', async (done) => {
     const expected = [
-      EMPTY_FLAG_SETS
+      EMPTY_FLAG_SET
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=    ')
+      .get('/client/get-treatments-with-config-by-set?key=test&flag-set=    ')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
   });
 
-  test('should be 400 if there are errors in key and flag-sets', async (done) => {
+  test('should be 400 if there are errors in key and flag-set', async (done) => {
     const expected = [
       'you passed an empty string, key must be a non-empty string.',
-      EMPTY_FLAG_SETS
+      EMPTY_FLAG_SET
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=&flag-sets=    ')
+      .get('/client/get-treatments-with-config-by-set?key=&flag-set=    ')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -171,7 +171,7 @@ describe('get-treatments-with-config-by-sets', () => {
       'attributes must be a plain object.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=my-experiment&attributes=lalala')
+      .get('/client/get-treatments-with-config-by-set?key=test&flag-set=my-experiment&attributes=lalala')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -180,11 +180,11 @@ describe('get-treatments-with-config-by-sets', () => {
   test('should be 400 if there are multiple errors', async (done) => {
     const expected = [
       'you passed an empty string, key must be a non-empty string.',
-      EMPTY_FLAG_SETS,
+      EMPTY_FLAG_SET,
       'attributes must be a plain object.'
     ];
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=     &flag-sets=&attributes="lalala"')
+      .get('/client/get-treatments-with-config-by-set?key=     &flag-set=&attributes="lalala"')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -193,13 +193,36 @@ describe('get-treatments-with-config-by-sets', () => {
   test('should be 400 if there are multiple errors in every input', async (done) => {
     const expected = [
       'you passed an empty string, key must be a non-empty string.',
-      EMPTY_FLAG_SETS,
+      EMPTY_FLAG_SET,
       'attributes must be a plain object.',
       'bucketing-key too long, bucketing-key must be 250 characters or less.'
     ];
     const key = getLongKey();
     const response = await request(app)
-      .get(`/client/get-treatments-with-config-by-sets?bucketing-key=${key}&key=     &flag-sets=&attributes="lalala"`)
+      .get(`/client/get-treatments-with-config-by-set?bucketing-key=${key}&key=     &flag-set=&attributes="lalala"`)
+      .set('Authorization', 'key_green');
+    expectErrorContaining(response, 400, expected);
+    done();
+  });
+
+  test('should be 400 with multiple evaluation', async (done) => {
+    const expected = [
+      MAYBE_FLAG_SETS
+    ];
+    const response = await request(app)
+      .get('/client/get-treatments-by-set?key=key_green&flag-set=set_green,set_purple')
+      .set('Authorization', 'key_green');
+    expectErrorContaining(response, 400, expected);
+    done();
+  });
+
+  test('should be 400 with multiple evaluation (POST)', async (done) => {
+    const expected = [
+      MAYBE_FLAG_SETS
+    ];
+    const response = await request(app)
+      .post('/client/get-treatments-by-set?key=key_green&flag-set=set_green,set_purple')
+      .set('Content-Type', 'application/json')
       .set('Authorization', 'key_green');
     expectErrorContaining(response, 400, expected);
     done();
@@ -207,7 +230,7 @@ describe('get-treatments-with-config-by-sets', () => {
 
   test('should be 200 if is valid attributes (GET)', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green&attributes={"test":"test"}')
+      .get('/client/get-treatments-with-config-by-set?key=key_green&flag-set=set_green&attributes={"test":"test"}')
       .set('Authorization', 'key_green');
     expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
     done();
@@ -215,7 +238,7 @@ describe('get-treatments-with-config-by-sets', () => {
 
   test('should be 200 when attributes is null (GET)', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green')
+      .get('/client/get-treatments-with-config-by-set?key=key_green&flag-set=set_green')
       .set('Authorization', 'key_green');
     expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
     done();
@@ -223,7 +246,7 @@ describe('get-treatments-with-config-by-sets', () => {
 
   test('should be 200 if is valid attributes (POST)', async (done) => {
     const response = await request(app)
-      .post('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green')
+      .post('/client/get-treatments-with-config-by-set?key=key_green&flag-set=set_green')
       .send({attributes: { test:'test' }})
       .set('Authorization', 'key_green');
     expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
@@ -232,7 +255,7 @@ describe('get-treatments-with-config-by-sets', () => {
 
   test('should be 200 if is valid attributes stringified (POST)', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green&attributes={"test":"test"}')
+      .get('/client/get-treatments-with-config-by-set?key=key_green&flag-set=set_green&attributes={"test":"test"}')
       .send(JSON.stringify({attributes: { test:'test' }}))
       .set('Authorization', 'key_green');
     expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
@@ -241,7 +264,7 @@ describe('get-treatments-with-config-by-sets', () => {
 
   test('should be 200 when attributes is null (POST)', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green')
+      .get('/client/get-treatments-with-config-by-set?key=key_green&flag-set=set_green')
       .send({
         attributes: null,
       })
@@ -250,27 +273,19 @@ describe('get-treatments-with-config-by-sets', () => {
     done();
   });
 
-  test('should be 200 with multiple evaluation but evualuate configured flag sets', async (done) => {
+  test('should be 200 and return an empty evaluation for not configured sets', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_green&flag-sets=set_green,set_purple,nonexistant-experiment')
+      .get('/client/get-treatments-with-config-by-set?key=key_purple&flag-set=set_purple')
       .set('Authorization', 'key_green');
-    expectOkMultipleResults(response, 200, expectedGreenResultsWithConfig, 3);
+    expectOkMultipleResults(response, 200, [], 0);
     done();
   });
 
-  test('should be 200 with multiple evaluation but evualuate configured flag sets', async (done) => {
+  test('should be 200 for configured flag sets', async (done) => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_purple&flag-sets=set_green,set_purple,nonexistant-experiment')
-      .set('Authorization', 'key_purple');
-    expectOkMultipleResults(response, 200, expectedPurpleResultsWithConfig, 3);
-    done();
-  });
-
-  test('should be 200 with multiple evaluation but evualuate configured flag sets', async (done) => {
-    const response = await request(app)
-      .get('/client/get-treatments-with-config-by-sets?key=key_purple&flag-sets=set_green,set_purple,nonexistant-experiment')
+      .get('/client/get-treatments-with-config-by-set?key=key_pink&flag-set=set_purple')
       .set('Authorization', 'key_pink');
-    expectOkMultipleResults(response, 200, expectedPinkResultsWithConfig, 5);
+    expectOkMultipleResults(response, 200, expectedPurpleResultsWithConfig, 3);
     done();
   });
 });

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,7 +1,16 @@
+const TRIMMABLE_SPACES_REGEX = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/;
+
+const EMPTY_FLAG_SET = 'you passed an empty flag-set, flag-set must be a non-empty string.';
 const EMPTY_FLAG_SETS = 'you passed an empty flag-sets, flag-sets must be a non-empty array.';
+const NULL_FLAG_SET = 'you passed a null or undefined flag-set, flag-set must be a non-empty string.';
 const NULL_FLAG_SETS = 'you passed a null or undefined flag-sets, flag-sets must be a non-empty array.';
+const MAYBE_FLAG_SETS = 'you passed an invalid flag-set, use /get-treatments-by-sets endpoint to evaluate an array of flag-sets.';
 
 module.exports = {
+  TRIMMABLE_SPACES_REGEX,
+  EMPTY_FLAG_SET,
   EMPTY_FLAG_SETS,
+  NULL_FLAG_SET,
   NULL_FLAG_SETS,
+  MAYBE_FLAG_SETS,
 };

--- a/utils/inputValidation/flagSet.js
+++ b/utils/inputValidation/flagSet.js
@@ -1,19 +1,18 @@
-const { NULL_FLAG_SETS, EMPTY_FLAG_SETS } = require('../constants');
 const errorWrapper = require('./wrapper/error');
 const okWrapper = require('./wrapper/ok');
-const TRIMMABLE_SPACES_REGEX = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/;
+const { NULL_FLAG_SET, EMPTY_FLAG_SET, MAYBE_FLAG_SETS, TRIMMABLE_SPACES_REGEX } = require('../constants');
 
 const validateFlagSet = (maybeFlagSet) => {
   // eslint-disable-next-line
-  if (maybeFlagSet == undefined) return errorWrapper(NULL_FLAG_SETS);
+  if (maybeFlagSet == undefined) return errorWrapper(NULL_FLAG_SET);
 
   if (TRIMMABLE_SPACES_REGEX.test(maybeFlagSet)) {
     console.log(`flag-sets "${maybeFlagSet}" has extra whitespace, trimming.`);
     maybeFlagSet = maybeFlagSet.trim();
   }
-  if (maybeFlagSet.length === 0) return errorWrapper(EMPTY_FLAG_SETS);
-
-  return okWrapper(maybeFlagSet.split(','));
+  if (maybeFlagSet.length === 0) return errorWrapper(EMPTY_FLAG_SET);
+  if (maybeFlagSet.includes(',')) return errorWrapper(MAYBE_FLAG_SETS);
+  return okWrapper(maybeFlagSet);
 };
 
 module.exports = validateFlagSet;

--- a/utils/inputValidation/flagSets.js
+++ b/utils/inputValidation/flagSets.js
@@ -1,0 +1,28 @@
+const errorWrapper = require('./wrapper/error');
+const okWrapper = require('./wrapper/ok');
+const lang = require('../lang');
+const validateFlagSet = require('./flagSet');
+const { EMPTY_FLAG_SETS, NULL_FLAG_SETS } = require('../constants');
+
+const validateFlagSets = (maybeFlagSets) => {
+  // eslint-disable-next-line eqeqeq
+  if (maybeFlagSets == undefined) return errorWrapper(NULL_FLAG_SETS);
+
+  maybeFlagSets = maybeFlagSets.split(',');
+
+  if (maybeFlagSets.length > 0) {
+    let validatedArray = [];
+    // Remove invalid values
+    maybeFlagSets.forEach(maybeFlagSet => {
+      const flagSetValidation = validateFlagSet(maybeFlagSet);
+      if (flagSetValidation.valid) validatedArray.push(flagSetValidation.value);
+    });
+
+    // Strip off duplicated values if we have valid flag sets then return
+    if (validatedArray.length) return okWrapper(lang.uniq(validatedArray));
+  }
+
+  return errorWrapper(EMPTY_FLAG_SETS);
+};
+
+module.exports = validateFlagSets;

--- a/utils/inputValidation/split.js
+++ b/utils/inputValidation/split.js
@@ -1,6 +1,6 @@
 const errorWrapper = require('./wrapper/error');
 const okWrapper = require('./wrapper/ok');
-const TRIMMABLE_SPACES_REGEX = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/;
+const { TRIMMABLE_SPACES_REGEX } = require('../constants');
 
 const validateSplit = (maybeSplit) => {
   // eslint-disable-next-line eqeqeq

--- a/utils/mocks/index.js
+++ b/utils/mocks/index.js
@@ -82,4 +82,70 @@ const integrations = [{
   type: 'GOOGLE_ANALYTICS_TO_SPLIT',
 }];
 
-module.exports = { core, scheduler, urls, startup, storage, sync, integrations, apiKeyMocksMap };
+const expectedGreenResults = {
+  'test_green': {
+    treatment: 'on',
+  },
+  'test_color': {
+    treatment: 'on',
+  },
+  'test_green_config': {
+    treatment: 'on',
+  },
+};
+const expectedPurpleResults = {
+  'test_purple': {
+    treatment: 'on',
+  },
+  'test_color': {
+    treatment: 'on',
+  },
+  'test_purple_config': {
+    treatment: 'on',
+  },
+};
+const expectedPinkResults = {
+  ...expectedGreenResults,
+  ...expectedPurpleResults,
+};
+
+const expectedGreenResultsWithConfig = {
+  'test_green': {
+    treatment: 'on',
+  },
+  'test_color': {
+    treatment: 'on',
+  },
+  'test_green_config': {
+    treatment: 'on',
+    config: '{"color":"green"}',
+  },
+};
+
+const expectedPurpleResultsWithConfig = {
+  'test_purple': {
+    treatment: 'on',
+  },
+  'test_color': {
+    treatment: 'on',
+  },
+  'test_purple_config': {
+    treatment: 'on',
+    config: '{"color":"purple"}',
+  },
+};
+
+const expectedPinkResultsWithConfig = {
+  ...expectedGreenResultsWithConfig,
+  ...expectedPurpleResultsWithConfig,
+};
+
+module.exports = {
+  core, scheduler, urls, startup, storage, sync, integrations, apiKeyMocksMap,
+  expectedGreenResults,
+  expectedPurpleResults,
+  expectedPinkResults,
+  expectedGreenResultsWithConfig,
+  expectedPurpleResultsWithConfig,
+  expectedPinkResultsWithConfig,
+};


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?
Add get treatments by flag set APIs
- GET /get-treatments-by-set
- POST /get-treatments-by-set
- GET /get-treatments-with-config-by-set
- POST /get-treatments-with-config-by-set

## How do we test the changes introduced in this PR?
Tests inlcuded
## Extra Notes
