### PR TITLE
Fixing OpenAPI spec for /manager/splits

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.x.x (coming soon)
+  - Fixed OpenAPI spec fot /manager/splits
+
 2.7.0 (Dec 20, 2024)
   - Added support to arm64 images.
   - Updated base image to node:20.13.1-alpine3.20

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -169,9 +169,12 @@ components:
           on: "{\"color\": \"blue\"}"
           off: "{\"color\": \"black\"}"
     Splits:
-      type: array
-      items:
-        $ref: '#/components/schemas/Split'
+      type: object
+      properties:
+        splits:
+          type: array
+          items:
+            $ref: '#/components/schemas/Split'
 
 security:
   - Authorization: []


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?
- Fixing OpenAPI spec for /manager/splits

<img width="1442" alt="Screenshot 2025-04-04 at 11 54 16 AM" src="https://github.com/user-attachments/assets/a1be191d-9c35-4129-b761-49d45ac9c7a9" />
