### PR TITLE
[FME-4362] update sdk version and add support for evaluation options

### DIFF
--- a/client/__tests__/allTreatments.test.js
+++ b/client/__tests__/allTreatments.test.js
@@ -259,4 +259,44 @@ describe('get-all-treatments', () => {
       .set('Authorization', 'test');
     expectOkAllTreatments(response, 200, expected, 2);
   });
+
+  test('should be 400 if options.properties is invalid (GET)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .get('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]&options={"properties":{"invalid":[1,2,3]}}')
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 400 if options.properties is invalid (POST)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .post('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]')
+      .send({
+        options: { properties: { invalid: [1, 2, 3] } },
+      })
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 200 if options.properties is valid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .set('Authorization', 'test');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if options.properties is valid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]')
+      .send({
+        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+      })
+      .set('Authorization', 'test');
+    expect(response.status).toBe(200);
+  });
 });

--- a/client/__tests__/allTreatmentsWithConfig.test.js
+++ b/client/__tests__/allTreatmentsWithConfig.test.js
@@ -267,4 +267,44 @@ describe('get-all-treatments-with-config', () => {
       .set('Authorization', 'test');
     expectOkAllTreatments(response, 200, expected, 2);
   });
+
+  test('should be 400 if options.properties is invalid (GET)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .get('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]&options={"properties":{"invalid":[1,2,3]}}')
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 400 if options.properties is invalid (POST)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .post('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]')
+      .send({
+        options: { properties: { invalid: [1, 2, 3] } },
+      })
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 200 if options.properties is valid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .set('Authorization', 'test');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if options.properties is valid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]')
+      .send({
+        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+      })
+      .set('Authorization', 'test');
+    expect(response.status).toBe(200);
+  });
 });

--- a/client/__tests__/treatment.test.js
+++ b/client/__tests__/treatment.test.js
@@ -247,4 +247,44 @@ describe('get-treatment', () => {
       .set('Authorization', 'test');
     expectOk(response, 200, 'control', 'nonexistant-experiment');
   });
+
+  test('should be 400 if options.properties is invalid (GET)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .get('/client/get-treatment?key=test&split-name=my-experiment&options={"properties":{"invalid":[1,2,3]}}')
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 400 if options.properties is invalid (POST)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .post('/client/get-treatment?key=test&split-name=my-experiment')
+      .send({
+        options: { properties: { invalid: [1, 2, 3] } },
+      })
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 200 if options.properties is valid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatment?key=test&split-name=my-experiment&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .set('Authorization', 'test');
+    expectOk(response, 200, 'on', 'my-experiment');
+  });
+
+  test('should be 200 if options.properties is valid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatment?key=test&split-name=my-experiment')
+      .send({
+        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+      })
+      .set('Authorization', 'test');
+    expectOk(response, 200, 'on', 'my-experiment');
+  });
 });

--- a/client/__tests__/treatmentWithConfig.test.js
+++ b/client/__tests__/treatmentWithConfig.test.js
@@ -229,4 +229,44 @@ describe('get-treatment-with-config', () => {
       .set('Authorization', 'test');
     expectOk(response, 200, 'control', 'nonexistant-experiment', null);
   });
+
+  test('should be 400 if options.properties is invalid (GET)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .get('/client/get-treatment-with-config?key=test&split-name=my-experiment&options={"properties":{"invalid":[1,2,3]}}')
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 400 if options.properties is invalid (POST)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .post('/client/get-treatment-with-config?key=test&split-name=my-experiment')
+      .send({
+        options: { properties: { invalid: [1, 2, 3] } },
+      })
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 200 if options.properties is valid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatment-with-config?key=test&split-name=my-experiment&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .set('Authorization', 'test');
+    expectOk(response, 200, 'on', 'my-experiment', '{"desc" : "this applies only to ON treatment"}');
+  });
+
+  test('should be 200 if options.properties is valid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatment-with-config?key=test&split-name=my-experiment')
+      .send({
+        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+      })
+      .set('Authorization', 'test');
+    expectOk(response, 200, 'on', 'my-experiment', '{"desc" : "this applies only to ON treatment"}');
+  });
 });

--- a/client/__tests__/treatments.test.js
+++ b/client/__tests__/treatments.test.js
@@ -267,4 +267,52 @@ describe('get-treatments', () => {
       },
     }, 3);
   });
+
+  test('should be 400 if options.properties is invalid (GET)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .get('/client/get-treatments?key=test&split-names=my-experiment&options={"properties":{"invalid":[1,2,3]}}')
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 400 if options.properties is invalid (POST)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .post('/client/get-treatments?key=test&split-names=my-experiment')
+      .send({
+        options: { properties: { invalid: [1, 2, 3] } },
+      })
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 200 if options.properties is valid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatments?key=test&split-names=my-experiment&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .set('Authorization', 'test');
+    expectOkMultipleResults(response, 200, {
+      'my-experiment': {
+        treatment: 'on',
+      },
+    }, 1);
+  });
+
+  test('should be 200 if options.properties is valid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatments?key=test&split-names=my-experiment')
+      .send({
+        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+      })
+      .set('Authorization', 'test');
+    expectOkMultipleResults(response, 200, {
+      'my-experiment': {
+        treatment: 'on',
+      },
+    }, 1);
+  });
 });

--- a/client/__tests__/treatmentsByFlagSets.test.js
+++ b/client/__tests__/treatmentsByFlagSets.test.js
@@ -7,7 +7,7 @@ const { expectedGreenResults, expectedPurpleResults, expectedPinkResults } = req
 jest.mock('node-fetch', () => {
   return jest.fn().mockImplementation((url) => {
 
-    const sdkUrl = 'https://sdk.test.io/api/splitChanges?s=1.1&since=-1';
+    const sdkUrl = 'https://sdk.test.io/api/splitChanges?s=1.3&since=-1';
     const splitChange2 = require('../../utils/mocks/splitchanges.since.-1.till.1602796638344.json');
     if (url.startsWith(sdkUrl)) return Promise.resolve({ status: 200, json: () => (splitChange2), ok: true });
 
@@ -272,5 +272,45 @@ describe('get-treatments-by-sets', () => {
       .get('/client/get-treatments-by-sets?key=key_purple&flag-sets=set_green,set_purple,nonexistant-experiment')
       .set('Authorization', 'key_pink');
     expectOkMultipleResults(response, 200, expectedPinkResults, 5);
+  });
+
+  test('should be 400 if options.properties is invalid (GET)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .get('/client/get-treatments-by-sets?key=test&flag-sets=set_green&options={"properties":{"invalid":[1,2,3]}}')
+      .set('Authorization', 'key_green');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 400 if options.properties is invalid (POST)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .post('/client/get-treatments-by-sets?key=test&flag-sets=set_green')
+      .send({
+        options: { properties: { invalid: [1, 2, 3] } },
+      })
+      .set('Authorization', 'key_green');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 200 if options.properties is valid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatments-by-sets?key=test&flag-sets=set_green&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .set('Authorization', 'key_green');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if options.properties is valid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatments-by-sets?key=test&flag-sets=set_green')
+      .send({
+        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+      })
+      .set('Authorization', 'key_green');
+    expect(response.status).toBe(200);
   });
 });

--- a/client/__tests__/treatmentsWithConfig.test.js
+++ b/client/__tests__/treatmentsWithConfig.test.js
@@ -252,4 +252,54 @@ describe('get-treatments-with-config', () => {
       },
     }, 3);
   });
+
+  test('should be 400 if options.properties is invalid (GET)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .get('/client/get-treatments-with-config?key=test&split-names=my-experiment&options={"properties":{"invalid":[1,2,3]}}')
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 400 if options.properties is invalid (POST)', async () => {
+    const expected = [
+      'options.properties must only contain boolean, string, or number values.'
+    ];
+    const response = await request(app)
+      .post('/client/get-treatments-with-config?key=test&split-names=my-experiment')
+      .send({
+        options: { properties: { invalid: [1, 2, 3] } },
+      })
+      .set('Authorization', 'test');
+    expectErrorContaining(response, 400, expected);
+  });
+
+  test('should be 200 if options.properties is valid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatments-with-config?key=test&split-names=my-experiment&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .set('Authorization', 'test');
+    expectOkMultipleResults(response, 200, {
+      'my-experiment': {
+        treatment: 'on',
+        config: '{"desc" : "this applies only to ON treatment"}',
+      },
+    }, 1);
+  });
+
+  test('should be 200 if options.properties is valid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatments-with-config?key=test&split-names=my-experiment')
+      .send({
+        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+      })
+      .set('Authorization', 'test');
+    expectOkMultipleResults(response, 200, {
+      'my-experiment': {
+        treatment: 'on',
+        config: '{"desc" : "this applies only to ON treatment"}',
+      },
+    }, 1);
+  });
 });

--- a/client/__tests__/treatmentsWithConfigByFlagSets.test.js
+++ b/client/__tests__/treatmentsWithConfigByFlagSets.test.js
@@ -6,7 +6,7 @@ const { expectedGreenResultsWithConfig, expectedPurpleResultsWithConfig, expecte
 
 jest.mock('node-fetch', () => {
   return jest.fn().mockImplementation((url) => {
-    const sdkUrl = 'https://sdk.test.io/api/splitChanges?s=1.1&since=-1';
+    const sdkUrl = 'https://sdk.test.io/api/splitChanges?s=1.3&since=-1';
     const splitChange2 = require('../../utils/mocks/splitchanges.since.-1.till.1602796638344.json');
     if (url.startsWith(sdkUrl)) return Promise.resolve({ status: 200, json: () => (splitChange2), ok: true});
     return Promise.resolve({ status: 200, json: () => ({}), ok: true });

--- a/client/client.controller.js
+++ b/client/client.controller.js
@@ -12,9 +12,10 @@ const getTreatment = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const featureFlag = req.splitio.featureFlagName;
   const attributes = req.splitio.attributes;
+  const evaluationOptions = req.splitio.options;
 
   try {
-    const evaluationResult = await client.getTreatment(key, featureFlag, attributes);
+    const evaluationResult = await client.getTreatment(key, featureFlag, attributes, evaluationOptions);
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     res.send({
@@ -36,9 +37,11 @@ const getTreatmentWithConfig = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const featureFlag = req.splitio.featureFlagName;
   const attributes = req.splitio.attributes;
+  const evaluationOptions = req.splitio.options;
+
 
   try {
-    const evaluationResult = await client.getTreatmentWithConfig(key, featureFlag, attributes);
+    const evaluationResult = await client.getTreatmentWithConfig(key, featureFlag, attributes, evaluationOptions);
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     res.send({
@@ -61,9 +64,10 @@ const getTreatments = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const featureFlags = req.splitio.featureFlagNames;
   const attributes = req.splitio.attributes;
+  const evaluationOptions = req.splitio.options;
 
   try {
-    const evaluationResults = await client.getTreatments(key, featureFlags, attributes);
+    const evaluationResults = await client.getTreatments(key, featureFlags, attributes, evaluationOptions);
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     const result = {};
@@ -89,9 +93,10 @@ const getTreatmentsWithConfig = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const featureFlags = req.splitio.featureFlagNames;
   const attributes = req.splitio.attributes;
+  const evaluationOptions = req.splitio.options;
 
   try {
-    const evaluationResults = await client.getTreatmentsWithConfig(key, featureFlags, attributes);
+    const evaluationResults = await client.getTreatmentsWithConfig(key, featureFlags, attributes, evaluationOptions);
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     res.send(evaluationResults);
@@ -110,9 +115,10 @@ const getTreatmentsByFlagSets = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const flagSets = req.splitio.flagSetNames;
   const attributes = req.splitio.attributes;
+  const evaluationOptions = req.splitio.options;
 
   try {
-    const evaluationResults = await client.getTreatmentsByFlagSets(key, flagSets, attributes);
+    const evaluationResults = await client.getTreatmentsByFlagSets(key, flagSets, attributes, evaluationOptions);
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     const result = {};
@@ -138,9 +144,10 @@ const getTreatmentsWithConfigByFlagSets = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const flagSets = req.splitio.flagSetNames;
   const attributes = req.splitio.attributes;
+  const evaluationOptions = req.splitio.options;
 
   try {
-    const evaluationResults = await client.getTreatmentsWithConfigByFlagSets(key, flagSets, attributes);
+    const evaluationResults = await client.getTreatmentsWithConfigByFlagSets(key, flagSets, attributes, evaluationOptions);
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     const result = evaluationResults;
@@ -176,8 +183,9 @@ const track = async (req, res) => {
  * allTreatments  matches featureFlags for passed trafficType and evaluates with passed key
  * @param {Object} keys
  * @param {Object} attributes
+ * @param {Object} evaluationOptions
  */
-const allTreatments = async (authorization, keys, attributes) => {
+const allTreatments = async (authorization, keys, attributes, evaluationOptions) => {
   const manager = environmentManager.getManager(authorization);
   const client = environmentManager.getClient(authorization);
   try {
@@ -192,7 +200,9 @@ const allTreatments = async (authorization, keys, attributes) => {
       const evaluation = await client.getTreatmentsWithConfig(
         parseKey(key.matchingKey, key.bucketingKey),
         featureFlagNames,
-        attributes);
+        attributes,
+        evaluationOptions
+      );
       // Saves result for each trafficType
       evaluations[key.trafficType] = evaluation;
     }
@@ -212,9 +222,11 @@ const allTreatments = async (authorization, keys, attributes) => {
 const getAllTreatmentsWithConfig = async (req, res) => {
   const keys = req.splitio.keys;
   const attributes = req.splitio.attributes;
+  const evaluationOptions = req.splitio.options;
 
   try {
-    const treatments = await allTreatments(req.headers.authorization, keys, attributes);
+    const treatments = await allTreatments(req.headers.authorization, keys, attributes, evaluationOptions);
+    console.log('options', evaluationOptions);
     environmentManager.updateLastEvaluation(req.headers.authorization);
     res.send(treatments);
   } catch (error) {
@@ -230,9 +242,10 @@ const getAllTreatmentsWithConfig = async (req, res) => {
 const getAllTreatments = async (req, res) => {
   const keys = req.splitio.keys;
   const attributes = req.splitio.attributes;
+  const evaluationOptions = req.splitio.options;
 
   try {
-    const treatments = await allTreatments(req.headers.authorization, keys, attributes);
+    const treatments = await allTreatments(req.headers.authorization, keys, attributes, evaluationOptions);
     // Erases the config property for treatments
     const trafficTypes = Object.keys(treatments);
     trafficTypes.forEach(trafficType => {

--- a/client/client.router.js
+++ b/client/client.router.js
@@ -12,6 +12,7 @@ const propertiesValidator = require('../utils/inputValidation/properties');
 const keysValidator = require('../utils/inputValidation/keys');
 const clientController = require('./client.controller');
 const { parseValidators } = require('../utils/utils');
+const validateEvaluationOptions = require('../utils/inputValidation/evaluationOptions');
 
 /**
  * treatmentValidation  performs input validation for treatment call.
@@ -24,8 +25,9 @@ const treatmentValidation = (req, res, next) => {
   const bucketingKeyValidation = req.query['bucketing-key'] !== undefined ? keyValidator(req.query['bucketing-key'], 'bucketing-key') : null;
   const featureFlagNameValidation = splitValidator(req.query['split-name']);
   const attributesValidation = attributesValidator(req.query.attributes);
+  const optionsValidation = validateEvaluationOptions(req.query.options);
 
-  const error = parseValidators([matchingKeyValidation, bucketingKeyValidation, featureFlagNameValidation, attributesValidation]);
+  const error = parseValidators([matchingKeyValidation, bucketingKeyValidation, featureFlagNameValidation, attributesValidation, optionsValidation]);
   if (error.length) {
     return res
       .status(400)
@@ -37,6 +39,7 @@ const treatmentValidation = (req, res, next) => {
       matchingKey: matchingKeyValidation.value,
       featureFlagName: featureFlagNameValidation.value,
       attributes: attributesValidation.value,
+      options: optionsValidation.value,
     };
 
     if (bucketingKeyValidation && bucketingKeyValidation.valid) req.splitio.bucketingKey = bucketingKeyValidation.value;
@@ -56,8 +59,9 @@ const treatmentsValidation = (req, res, next) => {
   const bucketingKeyValidation = req.query['bucketing-key'] !== undefined ? keyValidator(req.query['bucketing-key'], 'bucketing-key') : null;
   const featureFlagsNameValidation = splitsValidator(req.query['split-names']);
   const attributesValidation = attributesValidator(req.query.attributes);
+  const optionsValidation = validateEvaluationOptions(req.query.options);
 
-  const error = parseValidators([matchingKeyValidation, bucketingKeyValidation, featureFlagsNameValidation, attributesValidation]);
+  const error = parseValidators([matchingKeyValidation, bucketingKeyValidation, featureFlagsNameValidation, attributesValidation, optionsValidation]);
   if (error.length) {
     return res
       .status(400)
@@ -69,6 +73,7 @@ const treatmentsValidation = (req, res, next) => {
       matchingKey: matchingKeyValidation.value,
       featureFlagNames: featureFlagsNameValidation.value,
       attributes: attributesValidation.value,
+      options: optionsValidation.value,
     };
 
     if (bucketingKeyValidation && bucketingKeyValidation.valid) req.splitio.bucketingKey = bucketingKeyValidation.value;
@@ -88,8 +93,9 @@ const flagSetsValidation = (req, res, next) => {
   const bucketingKeyValidation = req.query['bucketing-key'] !== undefined ? keyValidator(req.query['bucketing-key'], 'bucketing-key') : null;
   const flagSetNameValidation = flagSetsValidator(req.query['flag-sets']);
   const attributesValidation = attributesValidator(req.query.attributes);
+  const optionsValidation = validateEvaluationOptions(req.query.options);
 
-  const error = parseValidators([matchingKeyValidation, bucketingKeyValidation, flagSetNameValidation, attributesValidation]);
+  const error = parseValidators([matchingKeyValidation, bucketingKeyValidation, flagSetNameValidation, attributesValidation, optionsValidation]);
   if (error.length) {
     return res
       .status(400)
@@ -101,6 +107,7 @@ const flagSetsValidation = (req, res, next) => {
       matchingKey: matchingKeyValidation.value,
       flagSetNames: flagSetNameValidation.value,
       attributes: attributesValidation.value,
+      options: optionsValidation.value,
     };
 
     if (bucketingKeyValidation && bucketingKeyValidation.valid) req.splitio.bucketingKey = bucketingKeyValidation.value;
@@ -151,8 +158,9 @@ const trackValidation = (req, res, next) => {
 const allTreatmentValidation = (req, res, next) => {
   const keysValidation = keysValidator(req.query.keys);
   const attributesValidation = attributesValidator(req.query.attributes);
+  const optionsValidation = validateEvaluationOptions(req.query.options);
 
-  const error = parseValidators([keysValidation, attributesValidation]);
+  const error = parseValidators([keysValidation, attributesValidation, optionsValidation]);
   if (error.length) {
     return res
       .status(400)
@@ -163,6 +171,7 @@ const allTreatmentValidation = (req, res, next) => {
     req.splitio = {
       keys: keysValidation.value,
       attributes: attributesValidation.value,
+      options: optionsValidation.value,
     };
   }
 
@@ -173,6 +182,12 @@ const allTreatmentValidation = (req, res, next) => {
 // by just connecting the json payload parsed on the right spot.
 const fwdAttributesFromPost = function parseAttributesMiddleware(req, res, next) {
   req.query.attributes = req.body.attributes;
+
+  next();
+};
+
+const fwdEvaluationOptionsFromPost = function parseOptionsMiddleware(req, res, next) {
+  req.query.options = req.body.options;
 
   next();
 };
@@ -201,14 +216,14 @@ router.get('/get-all-treatments-with-config', allTreatmentValidation, clientCont
 
 // Getting treatments as POST's for big attribute sets
 const JSON_PARSE_OPTS = { limit: '300kb' };
-router.post('/get-treatment',express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, handleBodyParserErr, treatmentValidation, clientController.getTreatment);
-router.post('/get-treatment-with-config', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, handleBodyParserErr, treatmentValidation, clientController.getTreatmentWithConfig);
-router.post('/get-treatments', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, handleBodyParserErr, treatmentsValidation, clientController.getTreatments);
-router.post('/get-treatments-with-config', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost,  handleBodyParserErr, treatmentsValidation, clientController.getTreatmentsWithConfig);
-router.post('/get-treatments-by-sets', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, handleBodyParserErr, flagSetsValidation, clientController.getTreatmentsByFlagSets);
-router.post('/get-treatments-with-config-by-sets', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost,  handleBodyParserErr, flagSetsValidation, clientController.getTreatmentsWithConfigByFlagSets);
-router.post('/get-all-treatments', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, handleBodyParserErr, allTreatmentValidation, clientController.getAllTreatments);
-router.post('/get-all-treatments-with-config', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, handleBodyParserErr, allTreatmentValidation, clientController.getAllTreatmentsWithConfig);
+router.post('/get-treatment',express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, fwdEvaluationOptionsFromPost, handleBodyParserErr, treatmentValidation, clientController.getTreatment);
+router.post('/get-treatment-with-config', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, fwdEvaluationOptionsFromPost, handleBodyParserErr, treatmentValidation, clientController.getTreatmentWithConfig);
+router.post('/get-treatments', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, fwdEvaluationOptionsFromPost, handleBodyParserErr, treatmentsValidation, clientController.getTreatments);
+router.post('/get-treatments-with-config', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, fwdEvaluationOptionsFromPost, handleBodyParserErr, treatmentsValidation, clientController.getTreatmentsWithConfig);
+router.post('/get-treatments-by-sets', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, fwdEvaluationOptionsFromPost, handleBodyParserErr, flagSetsValidation, clientController.getTreatmentsByFlagSets);
+router.post('/get-treatments-with-config-by-sets', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, fwdEvaluationOptionsFromPost, handleBodyParserErr, flagSetsValidation, clientController.getTreatmentsWithConfigByFlagSets);
+router.post('/get-all-treatments', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, fwdEvaluationOptionsFromPost, handleBodyParserErr, allTreatmentValidation, clientController.getAllTreatments);
+router.post('/get-all-treatments-with-config', express.json(JSON_PARSE_OPTS), fwdAttributesFromPost, fwdEvaluationOptionsFromPost, handleBodyParserErr, allTreatmentValidation, clientController.getAllTreatmentsWithConfig);
 
 // Other methods
 router.get('/track', trackValidation, clientController.track);

--- a/environmentManager/__tests__/manager.test.js
+++ b/environmentManager/__tests__/manager.test.js
@@ -4,7 +4,7 @@ const app = require('../../app');
 jest.mock('node-fetch', () => {
   return jest.fn().mockImplementation((url) => {
 
-    const sdkUrl = 'https://sdk.test.io/api/splitChanges?s=1.1&since=-1';
+    const sdkUrl = 'https://sdk.test.io/api/splitChanges?s=1.3&since=-1';
     const splitChange2 = require('../../utils/mocks/splitchanges.since.-1.till.1602796638344.json');
     if (url.startsWith(sdkUrl)) return Promise.resolve({ status: 200, json: () => (splitChange2), ok: true });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.7.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio": "11.0.3",
+        "@splitsoftware/splitio": "11.4.1",
         "config": "^3.3.9",
         "express": "^4.17.1",
         "morgan": "^1.9.1",
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
-      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -69,22 +69,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-      "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
+        "@babel/generator": "^7.28.0",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.4",
-        "@babel/parser": "^7.27.4",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.27.4",
-        "@babel/types": "^7.27.3",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -100,16 +100,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@babel/types": "^7.27.3",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -187,20 +187,30 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+      "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "debug": "^4.1.1",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "debug": "^4.4.1",
         "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2"
+        "resolve": "^1.22.10"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
@@ -382,13 +392,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.28.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -783,15 +793,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-      "integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+      "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -835,9 +845,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.5.tgz",
-      "integrity": "sha512-JF6uE2s67f0y2RZcm2kpAUEbD50vH62TyWVebxwHAlbSdM49VqPz8t4a1uIjp4NIOIZ4xzLfjY5emt/RCyC7TQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
+      "integrity": "sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -885,18 +895,18 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
-      "integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.0.tgz",
+      "integrity": "sha512-IjM1IoJNw72AZFlj33Cu8X0q2XK/6AaVC3jQu+cgQ5lThWD5ajnuUAml80dqRmOhmPkTH8uAwnpMu9Rvj0LTRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-globals": "^7.28.0",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "globals": "^11.1.0"
+        "@babel/traverse": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -923,13 +933,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
-      "integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+      "integrity": "sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -996,6 +1007,23 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
+      "integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1271,16 +1299,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
-      "integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
+      "integrity": "sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.3",
-        "@babel/plugin-transform-parameters": "^7.27.1"
+        "@babel/plugin-transform-destructuring": "^7.28.0",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1340,9 +1369,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-      "integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1407,9 +1436,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.5.tgz",
-      "integrity": "sha512-uhB8yHerfe3MWnuLAhEbeQ4afVoqv8BQsPqrTv7e/jZ9y00kJL6l9a/f4OWaKxotmjzewfEyXE1vgDJenkQ2/Q==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+      "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1604,13 +1633,13 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
-      "integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.0.tgz",
+      "integrity": "sha512-VmaxeGOwuDqzLl5JUkIRM1X2Qu2uKGxHEQWh+cvvbl7JuJRgKGJSfsEF/bUaxFhJl/XAyxBe7q7qSuTbKFuCyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.0",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-validator-option": "^7.27.1",
@@ -1624,19 +1653,20 @@
         "@babel/plugin-syntax-import-attributes": "^7.27.1",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.28.0",
         "@babel/plugin-transform-async-to-generator": "^7.27.1",
         "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.0",
         "@babel/plugin-transform-class-properties": "^7.27.1",
         "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.27.1",
+        "@babel/plugin-transform-classes": "^7.28.0",
         "@babel/plugin-transform-computed-properties": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0",
         "@babel/plugin-transform-dotall-regex": "^7.27.1",
         "@babel/plugin-transform-duplicate-keys": "^7.27.1",
         "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
         "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
         "@babel/plugin-transform-export-namespace-from": "^7.27.1",
         "@babel/plugin-transform-for-of": "^7.27.1",
@@ -1653,15 +1683,15 @@
         "@babel/plugin-transform-new-target": "^7.27.1",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
         "@babel/plugin-transform-numeric-separator": "^7.27.1",
-        "@babel/plugin-transform-object-rest-spread": "^7.27.2",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.0",
         "@babel/plugin-transform-object-super": "^7.27.1",
         "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
         "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-parameters": "^7.27.1",
+        "@babel/plugin-transform-parameters": "^7.27.7",
         "@babel/plugin-transform-private-methods": "^7.27.1",
         "@babel/plugin-transform-private-property-in-object": "^7.27.1",
         "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.28.0",
         "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
         "@babel/plugin-transform-reserved-words": "^7.27.1",
         "@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -1674,10 +1704,10 @@
         "@babel/plugin-transform-unicode-regex": "^7.27.1",
         "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.11.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.1",
-        "core-js-compat": "^3.40.0",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "core-js-compat": "^3.43.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1718,28 +1748,28 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
-        "@babel/parser": "^7.27.4",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.0",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/types": "^7.28.0",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
-      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1817,22 +1847,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1844,19 +1858,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -2263,18 +2264,14 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2287,27 +2284,17 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2411,12 +2398,12 @@
       }
     },
     "node_modules/@splitsoftware/splitio": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-11.0.3.tgz",
-      "integrity": "sha512-UtoixGfICCj52FfaVdI186Czw0qCvvEyCw/OtJVTsgM4Zq0k2mY8yKzQ7tSB/HJtzbUVnuPoxkwEcj0479stmg==",
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-11.4.1.tgz",
+      "integrity": "sha512-wipPwsWwXPRzvEs28VYahILsF8+Lor4tby2GB3CD9kn0C3sQ2Zf3/NaDH4i7acobMlRy2sQ5mu4eeRt15gLJyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio-commons": "2.0.2",
+        "@splitsoftware/splitio-commons": "2.4.1",
         "bloom-filters": "^3.0.4",
         "ioredis": "^4.28.0",
         "js-yaml": "^3.13.1",
@@ -2429,9 +2416,9 @@
       }
     },
     "node_modules/@splitsoftware/splitio-commons": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.2.tgz",
-      "integrity": "sha512-r2m3kwWnSuROT+7zTzhWBrM0DMRBGJNQcTyvXw8zLPPmBs/PnmAnxCy7uRpfMHOGbP9Q3Iju0bU/H5dG8svyiw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.4.1.tgz",
+      "integrity": "sha512-VcbWpPykfx19LTJ0yeZbV0u3PUIt8MuiZ2a8zqkNf9KnDnhau/XxS/ctoO5jYrg4Nk2rCi0fpt1TkTstqzbaYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ioredis": "^4.28.0",
@@ -2538,9 +2525,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
-      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -2647,6 +2634,19 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2777,14 +2777,14 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+      "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.4",
+        "@babel/compat-data": "^7.27.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -2792,27 +2792,27 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+      "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.3",
-        "core-js-compat": "^3.40.0"
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "core-js-compat": "^3.43.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+      "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.4"
+        "@babel/helper-define-polyfill-provider": "^0.6.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2992,9 +2992,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
       "dev": true,
       "funding": [
         {
@@ -3012,8 +3012,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -3100,9 +3100,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001724",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001724.tgz",
-      "integrity": "sha512-WqJo7p0TbHDOythNTqYujmaJTvtYRZrjpP8TCvH6Vb9CYJerJNKamKzIWOM4BkQatWj9H2lYulpdAQNBe7QhNA==",
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
       "dev": true,
       "funding": [
         {
@@ -3363,13 +3363,13 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
-      "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.44.0.tgz",
+      "integrity": "sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.25.0"
+        "browserslist": "^4.25.1"
       },
       "funding": {
         "type": "opencollective",
@@ -3571,9 +3571,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.173",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.173.tgz",
-      "integrity": "sha512-2bFhXP2zqSfQHugjqJIDFVwa+qIxyNApenmXTp9EjaKtdPrES5Qcn9/aSFy/NaP2E+fWG/zxKu/LBvY36p5VNQ==",
+      "version": "1.5.186",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.186.tgz",
+      "integrity": "sha512-lur7L4BFklgepaJxj4DqPk7vKbTEl0pajNlg2QjE5shefmlmBLm2HvQ7PMf1R/GvlevT/581cop33/quQcfX3A==",
       "dev": true,
       "license": "ISC"
     },
@@ -3802,22 +3802,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/eslint/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3856,19 +3840,6 @@
       "dependencies": {
         "p-limit": "^3.0.2"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -4217,9 +4188,9 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4414,13 +4385,19 @@
       }
     },
     "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -5824,16 +5801,16 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -6035,9 +6012,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7071,7 +7048,7 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
       "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
-      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7120,6 +7097,7 @@
       "version": "6.3.4",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
       "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7157,9 +7135,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.25.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.25.2.tgz",
-      "integrity": "sha512-V4JyoygUe5nCbn7bAD0fVKSC0yNcL3ROIQtGC7M0NATKuyosCSmMU6T0yDZIIuGpSxjsjZh/D2Ejb8lnF2jjxw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.0.tgz",
+      "integrity": "sha512-tS6LRyBhY6yAqxrfsA9IYpGWPUJOri6sclySa7TdC7XQfGLvTwDY531KLgfQwHEtQsn+sT4JlUspbeQDBVGWig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
@@ -7277,9 +7255,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
-    "@splitsoftware/splitio": "11.0.3",
+    "@splitsoftware/splitio": "11.4.1",
     "config": "^3.3.9",
     "express": "^4.17.1",
     "morgan": "^1.9.1",

--- a/utils/inputValidation/__tests__/evaluationOptions.test.js
+++ b/utils/inputValidation/__tests__/evaluationOptions.test.js
@@ -1,0 +1,57 @@
+const validateEvaluationOptions = require('../evaluationOptions');
+
+describe('validateEvaluationOptions', () => {
+  test('should be valid when options is undefined', () => {
+    const result = validateEvaluationOptions();
+    expect(result).toHaveProperty('valid', true);
+    expect(result).toHaveProperty('value', null);
+    expect(result).not.toHaveProperty('error');
+  });
+
+  test('should be valid when options is a plain object with allowed types', () => {
+    const options = { properties: { bool: true, str: 'test', num: 42 }};
+    const result = validateEvaluationOptions(options);
+    expect(result).toHaveProperty('valid', true);
+    expect(result).toHaveProperty('value', options);
+    expect(result).not.toHaveProperty('error');
+  });
+
+  test('should be valid when options is a stringified object with allowed types', () => {
+    const options = { bool: false, str: 'abc', num: 0 };
+    const result = validateEvaluationOptions(JSON.stringify(options));
+    expect(result).toHaveProperty('valid', true);
+    expect(result).toHaveProperty('value', options);
+    expect(result).not.toHaveProperty('error');
+  });
+
+  test('should return error when options is not an object', () => {
+    const result = validateEvaluationOptions('not an object');
+    expect(result).toHaveProperty('valid', false);
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('value');
+  });
+
+  test('should return error when options contains disallowed types', () => {
+    const options = { properties: { arr: [], obj: {}, func: () => {}, bool: true }};
+    const result = validateEvaluationOptions(options);
+    expect(result).toHaveProperty('valid', false);
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('value');
+  });
+
+  test('should return error when options is a stringified object with disallowed types', () => {
+    const options = { properties: { arr: [], obj: {}, bool: true }};
+    const result = validateEvaluationOptions(JSON.stringify(options));
+    expect(result).toHaveProperty('valid', false);
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('value');
+  }); 
+
+  test('should return error when options is a stringified object with disallowed types', () => {
+    const options = { properties: { arr: [], obj: {}, bool: true }};
+    const result = validateEvaluationOptions(JSON.stringify(options));
+    expect(result).toHaveProperty('valid', false);
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('value');
+  });
+});

--- a/utils/inputValidation/evaluationOptions.js
+++ b/utils/inputValidation/evaluationOptions.js
@@ -1,0 +1,34 @@
+const { isObject, isString } = require('../lang');
+const errorWrapper = require('./wrapper/error');
+const okWrapper = require('./wrapper/ok');
+
+const validateEvaluationOptions = (maybeOptions) => {
+  // eslint-disable-next-line eqeqeq
+  if (maybeOptions == undefined) {
+    return okWrapper(null);
+  }
+  try {
+    let options;
+    if (isString(maybeOptions)) {
+      maybeOptions = JSON.parse(maybeOptions);
+    }
+    if (isObject(maybeOptions)) { 
+      options = maybeOptions;
+    }
+    // If options.properties exists, validate its values
+    if (options && isObject(options.properties)) {
+      const allowedTypes = ['boolean', 'string', 'number'];
+      const invalid = Object.values(options.properties).some(
+        v => !allowedTypes.includes(typeof v)
+      );
+      if (invalid) {
+        return errorWrapper('options.properties must only contain boolean, string, or number values.');
+      }
+    }
+    return okWrapper(options);
+  } catch (e) {
+    return errorWrapper('options must be a plain object and options.properties must only contain boolean, string, or number values.');
+  }
+};
+
+module.exports = validateEvaluationOptions;


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?

- Update @splitsoftware/splitio to version `11.4.1`
- Add support for evaluation options in impressions
- Add optional `options` property to get treatment endpoints

## How do we test the changes introduced in this PR?
Added related tests

## Extra Notes
