### PR TITLE
[FME-7164] update swagger api-docs

### DIFF
--- a/environmentManager/__tests__/manager.test.js
+++ b/environmentManager/__tests__/manager.test.js
@@ -61,12 +61,12 @@ describe('environmentManager - manager endpoints', () => {
       .get('/manager/splits')
       .set('Authorization', 'key_green');
     expect(response.statusCode).toBe(200);
-    expect(response.body.splits.map(flag => {return {name: flag.name, prerequisites: flag.prerequisites};}))
+    expect(response.body.splits.map(flag => {return {name: flag.name, prerequisites: flag.prerequisites, impressionsDisabled: flag.impressionsDisabled};}))
       .toEqual(
         [
-          {name: 'test_green', prerequisites: [{flagName: 'flag1', treatments: ['on', 'v1']}, {flagName: 'flag2', treatments: ['off']}]},
-          {name: 'test_color', prerequisites: []},
-          {name: 'test_green_config', prerequisites: [{flagName: 'flag3', treatments: ['on', 'v2']}, {flagName: 'flag4', treatments: ['off']}, {flagName: 'flag5', treatments: ['off']}]}
+          {name: 'test_green', prerequisites: [{flagName: 'flag1', treatments: ['on', 'v1']}, {flagName: 'flag2', treatments: ['off']}], impressionsDisabled: true},
+          {name: 'test_color', prerequisites: [], impressionsDisabled: false},
+          {name: 'test_green_config', prerequisites: [{flagName: 'flag3', treatments: ['on', 'v2']}, {flagName: 'flag4', treatments: ['off']}, {flagName: 'flag5', treatments: ['off']}], impressionsDisabled: true}
         ]
       );
   });
@@ -76,12 +76,12 @@ describe('environmentManager - manager endpoints', () => {
       .get('/manager/splits')
       .set('Authorization', 'key_purple');
     expect(response.statusCode).toBe(200);
-    expect(response.body.splits.map(flag => {return {name: flag.name, prerequisites: flag.prerequisites};}))
+    expect(response.body.splits.map(flag => {return {name: flag.name, prerequisites: flag.prerequisites, impressionsDisabled: flag.impressionsDisabled};}))
       .toEqual(
         [
-          {name: 'test_color', prerequisites: []},
-          {name: 'test_purple', prerequisites: []},
-          {name: 'test_purple_config', prerequisites: []}
+          {name: 'test_color', prerequisites: [], impressionsDisabled: false},
+          {name: 'test_purple', prerequisites: [], impressionsDisabled: false},
+          {name: 'test_purple_config', prerequisites: [], impressionsDisabled: true}
         ]
       );
   });
@@ -130,6 +130,7 @@ describe('environmentManager - manager endpoints', () => {
     expect(response.body.name).toEqual('test_green');
     expect(response.body.sets).toEqual(['set_green']);
     expect(response.body.prerequisites).toEqual([{flagName: 'flag1', treatments: ['on', 'v1']}, {flagName: 'flag2', treatments: ['off']}]);
+    expect(response.body.impressionsDisabled).toEqual(true);
   });
 
   test('[/split] should be 200 if is valid authToken and return feature flag test_purple for key_purple', async () => {
@@ -140,6 +141,7 @@ describe('environmentManager - manager endpoints', () => {
     expect(response.body.name).toEqual('test_purple');
     expect(response.body.sets).toEqual(['set_purple']);
     expect(response.body.prerequisites).toEqual([]);
+    expect(response.body.impressionsDisabled).toEqual(false);
   });
 
   test('[/split] should be 404 if is valid authToken and return 404 for test_green using key_purple', async () => {
@@ -157,6 +159,7 @@ describe('environmentManager - manager endpoints', () => {
     expect(response.body.name).toEqual('test_green');
     expect(response.body.sets).toEqual(['set_green']);
     expect(response.body.prerequisites).toEqual([{flagName: 'flag1', treatments: ['on', 'v1']}, {flagName: 'flag2', treatments: ['off']}]);
+    expect(response.body.impressionsDisabled).toEqual(true);
   });
 
   test('[/split] should be 200 if is valid authToken and return feature flag test_purple for key_pink', async () => {
@@ -167,6 +170,7 @@ describe('environmentManager - manager endpoints', () => {
     expect(response.body.name).toEqual('test_purple');
     expect(response.body.sets).toEqual(['set_purple']);
     expect(response.body.prerequisites).toEqual([]);
+    expect(response.body.impressionsDisabled).toEqual(false);
   });
 
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -61,6 +61,13 @@ components:
         type: string
       description:  A JSON string of the attributes to include in the evaluation.
       example: "{\"my-attr1\": \"test\"}"
+    options:
+      in: query
+      name: options
+      schema:
+        type: string
+      description:  A JSON string of the options to include in the evaluation.
+      example: "{\"properties\": {\"package\":\"premium\",\"admin\":true,\"discount\":50}}"
     keys:
       in: query
       name: keys
@@ -101,7 +108,7 @@ components:
       example: "{\"prop1\": 1}"
   requestBodies:
     EvaluationRequestBody:
-      description: A JSON of the attributes to include in the evaluation.
+      description: A JSON of the attributes and options to include in the evaluation.
       required: false
       content:
         application/json:
@@ -113,7 +120,7 @@ components:
       properties:
         attributes:
           type: object
-      example: { attributes: { myattr1: 'test' }}
+      example: { attributes: { myattr1: 'test' }, properties: {"package":"premium","admin":true,"discount":50}}
     InputValidation:
       type: object
       properties:
@@ -159,6 +166,21 @@ components:
             type: string
         configs:
           type: object
+        impressionsDisabled:
+          type: boolean
+          description: Indicates if impressions are disabled for this split.
+        prerequisites:
+          type: array
+          description: List of prerequisites for this split.
+          items:
+            type: object
+            properties:
+              flagName:
+                type: string
+              treatments:
+                type: array
+                items:
+                  type: string
       example:
         name: my-split
         trafficType: my-traffic-type
@@ -168,6 +190,12 @@ components:
         config:
           on: "{\"color\": \"blue\"}"
           off: "{\"color\": \"black\"}"
+        impressionsDisabled: false
+        prerequisites:
+          - flagName: flag1
+            treatments: ["on", "v1"]
+          - flagName: flag2
+            treatments: ["off"]
     Splits:
       type: object
       properties:
@@ -191,6 +219,7 @@ paths:
         - $ref: '#/components/parameters/split-name'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -223,7 +252,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs single evaluation but receiving the attributes on the request body.
+      summary: performs single evaluation but receiving the attributes and options on the request body.
       description: Calls getTreatment method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -271,6 +300,7 @@ paths:
         - $ref: '#/components/parameters/split-name'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -306,7 +336,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs single evaluation and attachs config, but receiving the attributes on the request body.
+      summary: performs single evaluation and attachs config, but receiving the attributes and options on the request body.
       description: Calls getTreatmentWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -357,6 +387,7 @@ paths:
         - $ref: '#/components/parameters/split-names'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -386,7 +417,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once, but receiving the attributes on the request body.
+      summary: performs multiple evaluation at once, but receiving the attributes and options on the request body.
       description: Calls getTreatments method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -431,6 +462,7 @@ paths:
         - $ref: '#/components/parameters/split-names'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -462,7 +494,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once and attachs config, but receiving the attributes on the request body.
+      summary: performs multiple evaluation at once and attachs config, but receiving the attributes and options on the request body.
       description: Calls getTreatmentsWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -509,6 +541,7 @@ paths:
         - $ref: '#/components/parameters/flag-sets'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -538,7 +571,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once by sets, but receiving the attributes on the request body.
+      summary: performs multiple evaluation at once by sets, but receiving the attributes and options on the request body.
       description: Calls getTreatmentsByFlagSets method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -583,6 +616,7 @@ paths:
         - $ref: '#/components/parameters/flag-sets'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -614,7 +648,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation by sets at once and attachs config, but receiving the attributes on the request body.
+      summary: performs multiple evaluation by sets at once and attachs config, but receiving the attributes and options on the request body.
       description: Calls getTreatmentsWithConfigBySets method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -659,6 +693,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/keys'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -701,7 +736,7 @@ paths:
     post:
       tags:
         - client
-      summary: matches feature flags for passed trafficType and evaluates with passed key, but receiving the attributes on the request body.
+      summary: matches feature flags for passed trafficType and evaluates with passed key, but receiving the attributes and options on the request body.
       description: Calls getTreatments method from the SDK once it have all the splitNames for the keys provided.
       parameters:
         - $ref: '#/components/parameters/keys'
@@ -755,6 +790,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/keys'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -801,7 +837,7 @@ paths:
     post:
       tags:
         - client
-      summary: matches feature flags for passed trafficType and evaluates with passed key and attaches configs, but receiving the attributes on the request body.
+      summary: matches feature flags for passed trafficType and evaluates with passed key and attaches configs, but receiving the attributes and options on the request body.
       description: Calls getTreatmentsWithConfig method from the SDK once it have all the splitNames for the keys provided.
       parameters:
         - $ref: '#/components/parameters/keys'

--- a/utils/mocks/splitchanges.since.-1.till.1602796638344.json
+++ b/utils/mocks/splitchanges.since.-1.till.1602796638344.json
@@ -43,6 +43,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": true,
         "prerequisites": [
           { "n": "flag1", "ts": ["on","v1"] }, 
           { "n": "flag2", "ts": ["off"] }
@@ -90,6 +91,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": false,
         "prerequisites": []
       },
       {
@@ -136,6 +138,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": true,
         "prerequisites": [
           { "n": "flag3", "ts": ["on","v2"] }, 
           { "n": "flag4", "ts": ["off"] },
@@ -184,6 +187,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": false,
         "prerequisites": []
       },
       {
@@ -230,6 +234,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": true,
         "prerequisites": []
       }
     ],


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?
Update `/manager/split` and `/manager/splits` responses in api-docs to add `impressionsDisabled` and `prerequisites` properties
Update get treatment/s related definitions in open-api to add options parameter
Added impressions disabled property to split and splits tests

## How do we test the changes introduced in this PR?

## Extra Notes
