### PR TITLE
[FME-4363] Use properties param instead of options

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,7 @@
   - Updated base image to node:24.3.0-alpine3.21
 
 2.7.1 (Jun 25, 2025)
-  - Fixed OpenAPI spec fot /manager/splits
+  - Fixed OpenAPI spec for /manager/splits
   - Updated base image to node:24.2.0-alpine3.22
 
 2.7.0 (Dec 20, 2024)

--- a/client/__tests__/allTreatments.test.js
+++ b/client/__tests__/allTreatments.test.js
@@ -260,18 +260,35 @@ describe('get-all-treatments', () => {
     expectOkAllTreatments(response, 200, expected, 2);
   });
 
-  test('should be 200 if options.properties is valid (GET)', async () => {
+  test('should be 200 if properties is valid (GET)', async () => {
     const response = await request(app)
-      .get('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .get('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]&properties={"package":"premium","admin":true,"discount":50}')
       .set('Authorization', 'test');
     expect(response.status).toBe(200);
   });
 
-  test('should be 200 if options.properties is valid (POST)', async () => {
+  test('should be 200 if properties is valid (POST)', async () => {
     const response = await request(app)
       .post('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]')
       .send({
-        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+        properties: { package: 'premium', admin: true, discount: 50 },
+      })
+      .set('Authorization', 'test');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is invalid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]&properties={"foo": {"bar": 1}}')
+      .set('Authorization', 'test');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is invalid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-all-treatments?keys=[{"matchingKey":"test","trafficType":"localhost"}]')
+      .send({
+        properties: { foo: { bar: 1 } },
       })
       .set('Authorization', 'test');
     expect(response.status).toBe(200);

--- a/client/__tests__/allTreatmentsWithConfig.test.js
+++ b/client/__tests__/allTreatmentsWithConfig.test.js
@@ -268,18 +268,35 @@ describe('get-all-treatments-with-config', () => {
     expectOkAllTreatments(response, 200, expected, 2);
   });
 
-  test('should be 200 if options.properties is valid (GET)', async () => {
+  test('should be 200 if properties is valid (GET)', async () => {
     const response = await request(app)
-      .get('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .get('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]&properties={"package":"premium","admin":true,"discount":50}')
       .set('Authorization', 'test');
     expect(response.status).toBe(200);
   });
 
-  test('should be 200 if options.properties is valid (POST)', async () => {
+  test('should be 200 if properties is valid (POST)', async () => {
     const response = await request(app)
       .post('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]')
       .send({
-        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+        properties: { package: 'premium', admin: true, discount: 50 },
+      })
+      .set('Authorization', 'test');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is invalid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]&properties={"foo": {"bar": 1}}')
+      .set('Authorization', 'test');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is invalid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-all-treatments-with-config?keys=[{"matchingKey":"test","trafficType":"localhost"}]')
+      .send({
+        properties: { foo: { bar: 1 } },
       })
       .set('Authorization', 'test');
     expect(response.status).toBe(200);

--- a/client/__tests__/treatment.test.js
+++ b/client/__tests__/treatment.test.js
@@ -248,18 +248,35 @@ describe('get-treatment', () => {
     expectOk(response, 200, 'control', 'nonexistant-experiment');
   });
   
-  test('should be 200 if options.properties is valid (GET)', async () => {
+  test('should be 200 if properties is valid (GET)', async () => {
     const response = await request(app)
-      .get('/client/get-treatment?key=test&split-name=my-experiment&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .get('/client/get-treatment?key=test&split-name=my-experiment&properties={"package":"premium","admin":true,"discount":50}')
       .set('Authorization', 'test');
     expectOk(response, 200, 'on', 'my-experiment');
   });
 
-  test('should be 200 if options.properties is valid (POST)', async () => {
+  test('should be 200 if properties is valid (POST)', async () => {
     const response = await request(app)
       .post('/client/get-treatment?key=test&split-name=my-experiment')
       .send({
-        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+        properties: { package: 'premium', admin: true, discount: 50 },
+      })
+      .set('Authorization', 'test');
+    expectOk(response, 200, 'on', 'my-experiment');
+  });
+
+  test('should be 200 if properties is invalid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatment?key=test&split-name=my-experiment&properties={"foo": {"bar": 1}}')
+      .set('Authorization', 'test');
+    expectOk(response, 200, 'on', 'my-experiment');
+  });
+
+  test('should be 200 if properties is invalid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatment?key=test&split-name=my-experiment')
+      .send({
+        properties: { foo: { bar: 1 } },
       })
       .set('Authorization', 'test');
     expectOk(response, 200, 'on', 'my-experiment');

--- a/client/__tests__/treatmentWithConfig.test.js
+++ b/client/__tests__/treatmentWithConfig.test.js
@@ -230,18 +230,35 @@ describe('get-treatment-with-config', () => {
     expectOk(response, 200, 'control', 'nonexistant-experiment', null);
   });
 
-  test('should be 200 if options.properties is valid (GET)', async () => {
+  test('should be 200 if properties is valid (GET)', async () => {
     const response = await request(app)
-      .get('/client/get-treatment-with-config?key=test&split-name=my-experiment&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .get('/client/get-treatment-with-config?key=test&split-name=my-experiment&properties={"package":"premium","admin":true,"discount":50}')
       .set('Authorization', 'test');
     expectOk(response, 200, 'on', 'my-experiment', '{"desc" : "this applies only to ON treatment"}');
   });
 
-  test('should be 200 if options.properties is valid (POST)', async () => {
+  test('should be 200 if properties is valid (POST)', async () => {
     const response = await request(app)
       .post('/client/get-treatment-with-config?key=test&split-name=my-experiment')
       .send({
-        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+        properties: { package: 'premium', admin: true, discount: 50 },
+      })
+      .set('Authorization', 'test');
+    expectOk(response, 200, 'on', 'my-experiment', '{"desc" : "this applies only to ON treatment"}');
+  });
+
+  test('should be 200 if properties is invalid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatment-with-config?key=test&split-name=my-experiment&properties={"foo": {"bar": 1}}')
+      .set('Authorization', 'test');
+    expectOk(response, 200, 'on', 'my-experiment', '{"desc" : "this applies only to ON treatment"}');
+  });
+
+  test('should be 200 if properties is invalid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatment-with-config?key=test&split-name=my-experiment')
+      .send({
+        properties: { foo: { bar: 1 } },
       })
       .set('Authorization', 'test');
     expectOk(response, 200, 'on', 'my-experiment', '{"desc" : "this applies only to ON treatment"}');

--- a/client/__tests__/treatments.test.js
+++ b/client/__tests__/treatments.test.js
@@ -268,9 +268,9 @@ describe('get-treatments', () => {
     }, 3);
   });
 
-  test('should be 200 if options.properties is valid (GET)', async () => {
+  test('should be 200 if properties is valid (GET)', async () => {
     const response = await request(app)
-      .get('/client/get-treatments?key=test&split-names=my-experiment&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .get('/client/get-treatments?key=test&split-names=my-experiment&properties={"package":"premium","admin":true,"discount":50}')
       .set('Authorization', 'test');
     expectOkMultipleResults(response, 200, {
       'my-experiment': {
@@ -279,11 +279,36 @@ describe('get-treatments', () => {
     }, 1);
   });
 
-  test('should be 200 if options.properties is valid (POST)', async () => {
+  test('should be 200 if properties is valid (POST)', async () => {
     const response = await request(app)
       .post('/client/get-treatments?key=test&split-names=my-experiment')
       .send({
-        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+        properties: { package: 'premium', admin: true, discount: 50 },
+      })
+      .set('Authorization', 'test');
+    expectOkMultipleResults(response, 200, {
+      'my-experiment': {
+        treatment: 'on',
+      },
+    }, 1);
+  });
+
+  test('should be 200 if properties is invalid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatments?key=test&split-names=my-experiment&properties={"foo": {"bar": 1}}')
+      .set('Authorization', 'test');
+    expectOkMultipleResults(response, 200, {
+      'my-experiment': {
+        treatment: 'on',
+      },
+    }, 1);
+  });
+
+  test('should be 200 if properties is invalid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatments?key=test&split-names=my-experiment')
+      .send({
+        properties: { foo: { bar: 1 } },
       })
       .set('Authorization', 'test');
     expectOkMultipleResults(response, 200, {

--- a/client/__tests__/treatmentsByFlagSets.test.js
+++ b/client/__tests__/treatmentsByFlagSets.test.js
@@ -274,18 +274,35 @@ describe('get-treatments-by-sets', () => {
     expectOkMultipleResults(response, 200, expectedPinkResults, 5);
   });
   
-  test('should be 200 if options.properties is valid (GET)', async () => {
+  test('should be 200 if properties is valid (GET)', async () => {
     const response = await request(app)
-      .get('/client/get-treatments-by-sets?key=test&flag-sets=set_green&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .get('/client/get-treatments-by-sets?key=test&flag-sets=set_green&properties={"package":"premium","admin":true,"discount":50}')
       .set('Authorization', 'key_green');
     expect(response.status).toBe(200);
   });
 
-  test('should be 200 if options.properties is valid (POST)', async () => {
+  test('should be 200 if properties is valid (POST)', async () => {
     const response = await request(app)
       .post('/client/get-treatments-by-sets?key=test&flag-sets=set_green')
       .send({
-        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+        properties: { package: 'premium', admin: true, discount: 50 },
+      })
+      .set('Authorization', 'key_green');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is invalid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatments-by-sets?key=test&flag-sets=set_green&properties={"foo": {"bar": 1}}')
+      .set('Authorization', 'key_green');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is invalid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatments-by-sets?key=test&flag-sets=set_green')
+      .send({
+        properties: { foo: { bar: 1 } },
       })
       .set('Authorization', 'key_green');
     expect(response.status).toBe(200);

--- a/client/__tests__/treatmentsWithConfig.test.js
+++ b/client/__tests__/treatmentsWithConfig.test.js
@@ -253,9 +253,9 @@ describe('get-treatments-with-config', () => {
     }, 3);
   });
 
-  test('should be 200 if options.properties is valid (GET)', async () => {
+  test('should be 200 if properties is valid (GET)', async () => {
     const response = await request(app)
-      .get('/client/get-treatments-with-config?key=test&split-names=my-experiment&options={"properties":{"package":"premium","admin":true,"discount":50}}')
+      .get('/client/get-treatments-with-config?key=test&split-names=my-experiment&properties={"package":"premium","admin":true,"discount":50}')
       .set('Authorization', 'test');
     expectOkMultipleResults(response, 200, {
       'my-experiment': {
@@ -265,11 +265,38 @@ describe('get-treatments-with-config', () => {
     }, 1);
   });
 
-  test('should be 200 if options.properties is valid (POST)', async () => {
+  test('should be 200 if properties is valid (POST)', async () => {
     const response = await request(app)
       .post('/client/get-treatments-with-config?key=test&split-names=my-experiment')
       .send({
-        options: { properties: { package: 'premium', admin: true, discount: 50 } },
+        properties: { package: 'premium', admin: true, discount: 50 },
+      })
+      .set('Authorization', 'test');
+    expectOkMultipleResults(response, 200, {
+      'my-experiment': {
+        treatment: 'on',
+        config: '{"desc" : "this applies only to ON treatment"}',
+      },
+    }, 1);
+  });
+
+  test('should be 200 if properties is invalid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatments-with-config?key=test&split-names=my-experiment&properties={"foo": {"bar": 1}}')
+      .set('Authorization', 'test');
+    expectOkMultipleResults(response, 200, {
+      'my-experiment': {
+        treatment: 'on',
+        config: '{"desc" : "this applies only to ON treatment"}',
+      },
+    }, 1);
+  });
+
+  test('should be 200 if properties is invalid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatments-with-config?key=test&split-names=my-experiment')
+      .send({
+        properties: { foo: { bar: 1 } },
       })
       .set('Authorization', 'test');
     expectOkMultipleResults(response, 200, {

--- a/client/__tests__/treatmentsWithConfigByFlagSets.test.js
+++ b/client/__tests__/treatmentsWithConfigByFlagSets.test.js
@@ -249,4 +249,38 @@ describe('get-treatments-with-config-by-sets', () => {
       .set('Authorization', 'key_pink');
     expectOkMultipleResults(response, 200, expectedPinkResultsWithConfig, 5);
   });
+
+  test('should be 200 if properties is valid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=set_green&properties={"package":"premium","admin":true,"discount":50}')
+      .set('Authorization', 'key_green');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is valid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatments-with-config-by-sets?key=test&flag-sets=set_green')
+      .send({
+        properties: { package: 'premium', admin: true, discount: 50 },
+      })
+      .set('Authorization', 'key_green');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is invalid (GET)', async () => {
+    const response = await request(app)
+      .get('/client/get-treatments-with-config-by-sets?key=test&flag-sets=set_green&properties={"foo": {"bar": 1}}')
+      .set('Authorization', 'key_green');
+    expect(response.status).toBe(200);
+  });
+
+  test('should be 200 if properties is invalid (POST)', async () => {
+    const response = await request(app)
+      .post('/client/get-treatments-with-config-by-sets?key=test&flag-sets=set_green')
+      .send({
+        properties: { foo: { bar: 1 } },
+      })
+      .set('Authorization', 'key_green');
+    expect(response.status).toBe(200);
+  });
 });

--- a/client/client.controller.js
+++ b/client/client.controller.js
@@ -12,10 +12,10 @@ const getTreatment = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const featureFlag = req.splitio.featureFlagName;
   const attributes = req.splitio.attributes;
-  const evaluationOptions = req.splitio.options;
+  const properties = req.splitio.properties;
 
   try {
-    const evaluationResult = await client.getTreatment(key, featureFlag, attributes, evaluationOptions);
+    const evaluationResult = await client.getTreatment(key, featureFlag, attributes, { properties });
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     res.send({
@@ -37,11 +37,11 @@ const getTreatmentWithConfig = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const featureFlag = req.splitio.featureFlagName;
   const attributes = req.splitio.attributes;
-  const evaluationOptions = req.splitio.options;
+  const properties = req.splitio.properties;
 
 
   try {
-    const evaluationResult = await client.getTreatmentWithConfig(key, featureFlag, attributes, evaluationOptions);
+    const evaluationResult = await client.getTreatmentWithConfig(key, featureFlag, attributes, { properties });
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     res.send({
@@ -64,10 +64,10 @@ const getTreatments = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const featureFlags = req.splitio.featureFlagNames;
   const attributes = req.splitio.attributes;
-  const evaluationOptions = req.splitio.options;
+  const properties = req.splitio.properties;
 
   try {
-    const evaluationResults = await client.getTreatments(key, featureFlags, attributes, evaluationOptions);
+    const evaluationResults = await client.getTreatments(key, featureFlags, attributes, { properties });
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     const result = {};
@@ -93,10 +93,10 @@ const getTreatmentsWithConfig = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const featureFlags = req.splitio.featureFlagNames;
   const attributes = req.splitio.attributes;
-  const evaluationOptions = req.splitio.options;
+  const properties = req.splitio.properties;
 
   try {
-    const evaluationResults = await client.getTreatmentsWithConfig(key, featureFlags, attributes, evaluationOptions);
+    const evaluationResults = await client.getTreatmentsWithConfig(key, featureFlags, attributes, { properties });
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     res.send(evaluationResults);
@@ -115,10 +115,10 @@ const getTreatmentsByFlagSets = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const flagSets = req.splitio.flagSetNames;
   const attributes = req.splitio.attributes;
-  const evaluationOptions = req.splitio.options;
+  const properties = req.splitio.properties;
 
   try {
-    const evaluationResults = await client.getTreatmentsByFlagSets(key, flagSets, attributes, evaluationOptions);
+    const evaluationResults = await client.getTreatmentsByFlagSets(key, flagSets, attributes, { properties });
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     const result = {};
@@ -144,10 +144,10 @@ const getTreatmentsWithConfigByFlagSets = async (req, res) => {
   const key = parseKey(req.splitio.matchingKey, req.splitio.bucketingKey);
   const flagSets = req.splitio.flagSetNames;
   const attributes = req.splitio.attributes;
-  const evaluationOptions = req.splitio.options;
+  const properties = req.splitio.properties;
 
   try {
-    const evaluationResults = await client.getTreatmentsWithConfigByFlagSets(key, flagSets, attributes, evaluationOptions);
+    const evaluationResults = await client.getTreatmentsWithConfigByFlagSets(key, flagSets, attributes, { properties });
     environmentManager.updateLastEvaluation(req.headers.authorization);
 
     const result = evaluationResults;
@@ -185,7 +185,7 @@ const track = async (req, res) => {
  * @param {Object} attributes
  * @param {Object} evaluationOptions
  */
-const allTreatments = async (authorization, keys, attributes, evaluationOptions) => {
+const allTreatments = async (authorization, keys, attributes, properties) => {
   const manager = environmentManager.getManager(authorization);
   const client = environmentManager.getClient(authorization);
   try {
@@ -201,7 +201,7 @@ const allTreatments = async (authorization, keys, attributes, evaluationOptions)
         parseKey(key.matchingKey, key.bucketingKey),
         featureFlagNames,
         attributes,
-        evaluationOptions
+        { properties }
       );
       // Saves result for each trafficType
       evaluations[key.trafficType] = evaluation;
@@ -222,10 +222,10 @@ const allTreatments = async (authorization, keys, attributes, evaluationOptions)
 const getAllTreatmentsWithConfig = async (req, res) => {
   const keys = req.splitio.keys;
   const attributes = req.splitio.attributes;
-  const evaluationOptions = req.splitio.options;
+  const properties = req.splitio.properties;
 
   try {
-    const treatments = await allTreatments(req.headers.authorization, keys, attributes, evaluationOptions);
+    const treatments = await allTreatments(req.headers.authorization, keys, attributes, properties);
     environmentManager.updateLastEvaluation(req.headers.authorization);
     res.send(treatments);
   } catch (error) {
@@ -241,10 +241,10 @@ const getAllTreatmentsWithConfig = async (req, res) => {
 const getAllTreatments = async (req, res) => {
   const keys = req.splitio.keys;
   const attributes = req.splitio.attributes;
-  const evaluationOptions = req.splitio.options;
+  const properties = req.splitio.properties;
 
   try {
-    const treatments = await allTreatments(req.headers.authorization, keys, attributes, evaluationOptions);
+    const treatments = await allTreatments(req.headers.authorization, keys, attributes, properties);
     // Erases the config property for treatments
     const trafficTypes = Object.keys(treatments);
     trafficTypes.forEach(trafficType => {

--- a/environmentManager/__tests__/manager.test.js
+++ b/environmentManager/__tests__/manager.test.js
@@ -61,12 +61,12 @@ describe('environmentManager - manager endpoints', () => {
       .get('/manager/splits')
       .set('Authorization', 'key_green');
     expect(response.statusCode).toBe(200);
-    expect(response.body.splits.map(flag => {return {name: flag.name, prerequisites: flag.prerequisites};}))
+    expect(response.body.splits.map(flag => {return {name: flag.name, prerequisites: flag.prerequisites, impressionsDisabled: flag.impressionsDisabled};}))
       .toEqual(
         [
-          {name: 'test_green', prerequisites: [{flagName: 'flag1', treatments: ['on', 'v1']}, {flagName: 'flag2', treatments: ['off']}]},
-          {name: 'test_color', prerequisites: []},
-          {name: 'test_green_config', prerequisites: [{flagName: 'flag3', treatments: ['on', 'v2']}, {flagName: 'flag4', treatments: ['off']}, {flagName: 'flag5', treatments: ['off']}]}
+          {name: 'test_green', prerequisites: [{flagName: 'flag1', treatments: ['on', 'v1']}, {flagName: 'flag2', treatments: ['off']}], impressionsDisabled: true},
+          {name: 'test_color', prerequisites: [], impressionsDisabled: false},
+          {name: 'test_green_config', prerequisites: [{flagName: 'flag3', treatments: ['on', 'v2']}, {flagName: 'flag4', treatments: ['off']}, {flagName: 'flag5', treatments: ['off']}], impressionsDisabled: true}
         ]
       );
   });
@@ -76,12 +76,12 @@ describe('environmentManager - manager endpoints', () => {
       .get('/manager/splits')
       .set('Authorization', 'key_purple');
     expect(response.statusCode).toBe(200);
-    expect(response.body.splits.map(flag => {return {name: flag.name, prerequisites: flag.prerequisites};}))
+    expect(response.body.splits.map(flag => {return {name: flag.name, prerequisites: flag.prerequisites, impressionsDisabled: flag.impressionsDisabled};}))
       .toEqual(
         [
-          {name: 'test_color', prerequisites: []},
-          {name: 'test_purple', prerequisites: []},
-          {name: 'test_purple_config', prerequisites: []}
+          {name: 'test_color', prerequisites: [], impressionsDisabled: false},
+          {name: 'test_purple', prerequisites: [], impressionsDisabled: false},
+          {name: 'test_purple_config', prerequisites: [], impressionsDisabled: true}
         ]
       );
   });
@@ -130,6 +130,7 @@ describe('environmentManager - manager endpoints', () => {
     expect(response.body.name).toEqual('test_green');
     expect(response.body.sets).toEqual(['set_green']);
     expect(response.body.prerequisites).toEqual([{flagName: 'flag1', treatments: ['on', 'v1']}, {flagName: 'flag2', treatments: ['off']}]);
+    expect(response.body.impressionsDisabled).toEqual(true);
   });
 
   test('[/split] should be 200 if is valid authToken and return feature flag test_purple for key_purple', async () => {
@@ -140,6 +141,7 @@ describe('environmentManager - manager endpoints', () => {
     expect(response.body.name).toEqual('test_purple');
     expect(response.body.sets).toEqual(['set_purple']);
     expect(response.body.prerequisites).toEqual([]);
+    expect(response.body.impressionsDisabled).toEqual(false);
   });
 
   test('[/split] should be 404 if is valid authToken and return 404 for test_green using key_purple', async () => {
@@ -157,6 +159,7 @@ describe('environmentManager - manager endpoints', () => {
     expect(response.body.name).toEqual('test_green');
     expect(response.body.sets).toEqual(['set_green']);
     expect(response.body.prerequisites).toEqual([{flagName: 'flag1', treatments: ['on', 'v1']}, {flagName: 'flag2', treatments: ['off']}]);
+    expect(response.body.impressionsDisabled).toEqual(true);
   });
 
   test('[/split] should be 200 if is valid authToken and return feature flag test_purple for key_pink', async () => {
@@ -167,6 +170,7 @@ describe('environmentManager - manager endpoints', () => {
     expect(response.body.name).toEqual('test_purple');
     expect(response.body.sets).toEqual(['set_purple']);
     expect(response.body.prerequisites).toEqual([]);
+    expect(response.body.impressionsDisabled).toEqual(false);
   });
 
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -61,13 +61,13 @@ components:
         type: string
       description:  A JSON string of the attributes to include in the evaluation.
       example: "{\"my-attr1\": \"test\"}"
-    options:
+    evaluation-properties:
       in: query
-      name: options
+      name: properties
       schema:
         type: string
-      description:  A JSON string of the options to include in the evaluation.
-      example: "{\"properties\": {\"package\":\"premium\",\"admin\":true,\"discount\":50}}"
+      description:  A JSON string of the properties to include in the evaluation. Must be a flat object with up to 15 keys for GET requests. Values must be boolean, string, number, or null.
+      example: '{"package":"premium","admin":true,"discount":50}'
     keys:
       in: query
       name: keys
@@ -108,7 +108,7 @@ components:
       example: "{\"prop1\": 1}"
   requestBodies:
     EvaluationRequestBody:
-      description: A JSON of the attributes and options to include in the evaluation.
+      description: A JSON of the attributes and properties to include in the evaluation.
       required: false
       content:
         application/json:
@@ -119,6 +119,8 @@ components:
       type: object
       properties:
         attributes:
+          type: object
+        properties:
           type: object
       example: { attributes: { myattr1: 'test' }, properties: {"package":"premium","admin":true,"discount":50}}
     InputValidation:
@@ -219,7 +221,7 @@ paths:
         - $ref: '#/components/parameters/split-name'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/options'
+        - $ref: '#/components/parameters/evaluation-properties'
       responses:
         '200':
           description: Evaluation result
@@ -227,7 +229,7 @@ paths:
             application/json:
               schema:
                 type: object
-                properties:
+                evaluation-properties:
                   splitName:
                     type: string
                   treatment:
@@ -252,7 +254,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs single evaluation but receiving the attributes and options on the request body.
+      summary: performs single evaluation but receiving the attributes and properties on the request body.
       description: Calls getTreatment method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -300,7 +302,7 @@ paths:
         - $ref: '#/components/parameters/split-name'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/options'
+        - $ref: '#/components/parameters/evaluation-properties'
       responses:
         '200':
           description: Evaluation result
@@ -336,7 +338,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs single evaluation and attachs config, but receiving the attributes and options on the request body.
+      summary: performs single evaluation and attachs config, but receiving the attributes and properties on the request body.
       description: Calls getTreatmentWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -387,7 +389,7 @@ paths:
         - $ref: '#/components/parameters/split-names'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/options'
+        - $ref: '#/components/parameters/evaluation-properties'
       responses:
         '200':
           description: Evaluation result
@@ -417,7 +419,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once, but receiving the attributes and options on the request body.
+      summary: performs multiple evaluation at once, but receiving the attributes and properties on the request body.
       description: Calls getTreatments method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -462,7 +464,7 @@ paths:
         - $ref: '#/components/parameters/split-names'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/options'
+        - $ref: '#/components/parameters/evaluation-properties'
       responses:
         '200':
           description: Evaluation result
@@ -494,7 +496,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once and attachs config, but receiving the attributes and options on the request body.
+      summary: performs multiple evaluation at once and attachs config, but receiving the attributes and properties on the request body.
       description: Calls getTreatmentsWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -541,7 +543,7 @@ paths:
         - $ref: '#/components/parameters/flag-sets'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/options'
+        - $ref: '#/components/parameters/evaluation-properties'
       responses:
         '200':
           description: Evaluation result
@@ -571,7 +573,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once by sets, but receiving the attributes and options on the request body.
+      summary: performs multiple evaluation at once by sets, but receiving the attributes and properties on the request body.
       description: Calls getTreatmentsByFlagSets method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -616,7 +618,7 @@ paths:
         - $ref: '#/components/parameters/flag-sets'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/options'
+        - $ref: '#/components/parameters/evaluation-properties'
       responses:
         '200':
           description: Evaluation result
@@ -648,7 +650,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation by sets at once and attachs config, but receiving the attributes and options on the request body.
+      summary: performs multiple evaluation by sets at once and attachs config, but receiving the attributes and properties on the request body.
       description: Calls getTreatmentsWithConfigBySets method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -693,7 +695,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/keys'
         - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/options'
+        - $ref: '#/components/parameters/evaluation-properties'
       responses:
         '200':
           description: Evaluation result
@@ -736,7 +738,7 @@ paths:
     post:
       tags:
         - client
-      summary: matches feature flags for passed trafficType and evaluates with passed key, but receiving the attributes and options on the request body.
+      summary: matches feature flags for passed trafficType and evaluates with passed key, but receiving the attributes and properties on the request body.
       description: Calls getTreatments method from the SDK once it have all the splitNames for the keys provided.
       parameters:
         - $ref: '#/components/parameters/keys'
@@ -790,7 +792,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/keys'
         - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/options'
+        - $ref: '#/components/parameters/evaluation-properties'
       responses:
         '200':
           description: Evaluation result
@@ -837,7 +839,7 @@ paths:
     post:
       tags:
         - client
-      summary: matches feature flags for passed trafficType and evaluates with passed key and attaches configs, but receiving the attributes and options on the request body.
+      summary: matches feature flags for passed trafficType and evaluates with passed key and attaches configs, but receiving the attributes and properties on the request body.
       description: Calls getTreatmentsWithConfig method from the SDK once it have all the splitNames for the keys provided.
       parameters:
         - $ref: '#/components/parameters/keys'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -67,7 +67,7 @@ components:
       schema:
         type: string
       description:  A JSON string of the properties to include in the evaluation. Must be a flat object with up to 15 keys for GET requests. Values must be boolean, string, number, or null.
-      example: '{"package":"premium","admin":true,"discount":50}'
+      example: "{\"package\": \"premium\", \"admin\": true, \"discount\": 50 }"
     keys:
       in: query
       name: keys
@@ -122,7 +122,7 @@ components:
           type: object
         properties:
           type: object
-      example: { attributes: { myattr1: 'test' }, properties: {"package":"premium","admin":true,"discount":50}}
+      example: { attributes: { myattr1: "test" }, properties: { package: "premium", admin: true, discount: 50 }}
     InputValidation:
       type: object
       properties:
@@ -295,7 +295,7 @@ paths:
     get:
       tags:
         - client
-      summary: performs single evaluation and attachs config
+      summary: performs single evaluation and attaches config
       description: Calls getTreatmentWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -338,7 +338,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs single evaluation and attachs config, but receiving the attributes and properties on the request body.
+      summary: performs single evaluation and attaches config, but receiving the attributes and properties on the request body.
       description: Calls getTreatmentWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -457,7 +457,7 @@ paths:
     get:
       tags:
         - client
-      summary: performs multiple evaluation at once and attachs config
+      summary: performs multiple evaluation at once and attaches config
       description: Calls getTreatmentsWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -496,7 +496,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once and attachs config, but receiving the attributes and properties on the request body.
+      summary: performs multiple evaluation at once and attaches config, but receiving the attributes and properties on the request body.
       description: Calls getTreatmentsWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -611,7 +611,7 @@ paths:
     get:
       tags:
         - client
-      summary: performs multiple evaluation by sets at once and attachs config
+      summary: performs multiple evaluation by sets at once and attaches config
       description: Calls getTreatmentsWithConfigBySets method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -650,7 +650,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation by sets at once and attachs config, but receiving the attributes and properties on the request body.
+      summary: performs multiple evaluation by sets at once and attaches config, but receiving the attributes and properties on the request body.
       description: Calls getTreatmentsWithConfigBySets method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -1238,4 +1238,3 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
-

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -61,6 +61,13 @@ components:
         type: string
       description:  A JSON string of the attributes to include in the evaluation.
       example: "{\"my-attr1\": \"test\"}"
+    options:
+      in: query
+      name: options
+      schema:
+        type: string
+      description:  A JSON string of the options to include in the evaluation.
+      example: "{\"properties\": {\"package\":\"premium\",\"admin\":true,\"discount\":50}}"
     keys:
       in: query
       name: keys
@@ -101,7 +108,7 @@ components:
       example: "{\"prop1\": 1}"
   requestBodies:
     EvaluationRequestBody:
-      description: A JSON of the attributes to include in the evaluation.
+      description: A JSON of the attributes and options to include in the evaluation.
       required: false
       content:
         application/json:
@@ -113,7 +120,7 @@ components:
       properties:
         attributes:
           type: object
-      example: { attributes: { myattr1: 'test' }}
+      example: { attributes: { myattr1: 'test' }, properties: {"package":"premium","admin":true,"discount":50}}
     InputValidation:
       type: object
       properties:
@@ -159,6 +166,21 @@ components:
             type: string
         configs:
           type: object
+        impressionsDisabled:
+          type: boolean
+          description: Indicates if impressions are disabled for this split.
+        prerequisites:
+          type: array
+          description: List of prerequisites for this split.
+          items:
+            type: object
+            properties:
+              flagName:
+                type: string
+              treatments:
+                type: array
+                items:
+                  type: string
       example:
         name: my-split
         trafficType: my-traffic-type
@@ -168,6 +190,12 @@ components:
         config:
           on: "{\"color\": \"blue\"}"
           off: "{\"color\": \"black\"}"
+        impressionsDisabled: false
+        prerequisites:
+          - flagName: flag1
+            treatments: ["on", "v1"]
+          - flagName: flag2
+            treatments: ["off"]
     Splits:
       type: object
       properties:
@@ -191,6 +219,7 @@ paths:
         - $ref: '#/components/parameters/split-name'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -223,7 +252,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs single evaluation but receiving the attributes on the request body.
+      summary: performs single evaluation but receiving the attributes and options on the request body.
       description: Calls getTreatment method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -271,6 +300,7 @@ paths:
         - $ref: '#/components/parameters/split-name'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -306,7 +336,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs single evaluation and attachs config, but receiving the attributes on the request body.
+      summary: performs single evaluation and attachs config, but receiving the attributes and options on the request body.
       description: Calls getTreatmentWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -357,6 +387,7 @@ paths:
         - $ref: '#/components/parameters/split-names'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -386,7 +417,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once, but receiving the attributes on the request body.
+      summary: performs multiple evaluation at once, but receiving the attributes and options on the request body.
       description: Calls getTreatments method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -431,6 +462,7 @@ paths:
         - $ref: '#/components/parameters/split-names'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -462,7 +494,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once and attachs config, but receiving the attributes on the request body.
+      summary: performs multiple evaluation at once and attachs config, but receiving the attributes and options on the request body.
       description: Calls getTreatmentsWithConfig method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -509,6 +541,7 @@ paths:
         - $ref: '#/components/parameters/flag-sets'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -538,7 +571,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation at once by sets, but receiving the attributes on the request body.
+      summary: performs multiple evaluation at once by sets, but receiving the attributes and options on the request body.
       description: Calls getTreatmentsByFlagSets method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -583,6 +616,7 @@ paths:
         - $ref: '#/components/parameters/flag-sets'
         - $ref: '#/components/parameters/bucketing-key'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -614,7 +648,7 @@ paths:
     post:
       tags:
         - client
-      summary: performs multiple evaluation by sets at once and attachs config, but receiving the attributes on the request body.
+      summary: performs multiple evaluation by sets at once and attachs config, but receiving the attributes and options on the request body.
       description: Calls getTreatmentsWithConfigBySets method from the SDK.
       parameters:
         - $ref: '#/components/parameters/key'
@@ -659,6 +693,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/keys'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -701,7 +736,7 @@ paths:
     post:
       tags:
         - client
-      summary: matches feature flags for passed trafficType and evaluates with passed key, but receiving the attributes on the request body.
+      summary: matches feature flags for passed trafficType and evaluates with passed key, but receiving the attributes and options on the request body.
       description: Calls getTreatments method from the SDK once it have all the splitNames for the keys provided.
       parameters:
         - $ref: '#/components/parameters/keys'
@@ -755,6 +790,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/keys'
         - $ref: '#/components/parameters/attributes'
+        - $ref: '#/components/parameters/options'
       responses:
         '200':
           description: Evaluation result
@@ -801,7 +837,7 @@ paths:
     post:
       tags:
         - client
-      summary: matches feature flags for passed trafficType and evaluates with passed key and attaches configs, but receiving the attributes on the request body.
+      summary: matches feature flags for passed trafficType and evaluates with passed key and attaches configs, but receiving the attributes and options on the request body.
       description: Calls getTreatmentsWithConfig method from the SDK once it have all the splitNames for the keys provided.
       parameters:
         - $ref: '#/components/parameters/keys'

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -3,8 +3,13 @@ const TRIMMABLE_SPACES_REGEX = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/;
 const EMPTY_FLAG_SETS = 'you passed an empty flag-sets, flag-sets must be a non-empty array.';
 const NULL_FLAG_SETS = 'you passed a null or undefined flag-sets, flag-sets must be a non-empty array.';
 
+const PROPERTIES_WARNING = 'Warning: properties must be a plain object with only boolean, string, number or null values. Properties will be ignored.';
+const PROPERTIES_KEY_LIMIT_WARNING = 'Warning: properties object must not have more than 15 keys. Properties will be ignored.';
+
 module.exports = {
   TRIMMABLE_SPACES_REGEX,
   EMPTY_FLAG_SETS,
   NULL_FLAG_SETS,
+  PROPERTIES_WARNING,
+  PROPERTIES_KEY_LIMIT_WARNING,
 };

--- a/utils/inputValidation/__tests__/properties.test.js
+++ b/utils/inputValidation/__tests__/properties.test.js
@@ -1,30 +1,45 @@
-const { validateProperties, validateEvaluationOptions } = require('../properties');
+const { validateProperties } = require('../properties');
+const { PROPERTIES_WARNING, PROPERTIES_KEY_LIMIT_WARNING } = require('../../constants');
 
 describe('validateProperties', () => {
+  let logSpy;
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  const invalidObj = (() => {
+    const obj = {};
+    for (let i = 0; i < 16; i++) obj['k' + i] = i;
+    return obj;
+  })();
+
   test('should return error on invalid properties', done => {
-    const expected = 'properties must be a plain object with only boolean, string, number or null values.';
     const result = validateProperties('test');
-    expect(result).toHaveProperty('valid', false);
-    expect(result).toHaveProperty('error', expected);
-    expect(result).not.toHaveProperty('value');
+    expect(result).toHaveProperty('valid', true);
+    expect(result).toHaveProperty('value', null);
+    expect(result).not.toHaveProperty('error');
+    expect(logSpy).toHaveBeenCalledWith(PROPERTIES_WARNING);
     done();
   });
 
   test('should return error on invalid properties 2', done => {
-    const expected = 'properties must be a plain object with only boolean, string, number or null values.';
     const result = validateProperties('[]');
-    expect(result).toHaveProperty('valid', false);
-    expect(result).toHaveProperty('error', expected);
-    expect(result).not.toHaveProperty('value');
+    expect(result).toHaveProperty('valid', true );
+    expect(result).toHaveProperty('value', null);
+    expect(result).not.toHaveProperty('error');
+    expect(logSpy).toHaveBeenCalledWith(PROPERTIES_WARNING);
     done();
   });
 
   test('should return error on invalid properties 3', done => {
-    const expected = 'properties must be a plain object with only boolean, string, number or null values.';
     const result = validateProperties('true');
-    expect(result).toHaveProperty('valid', false);
-    expect(result).toHaveProperty('error', expected);
-    expect(result).not.toHaveProperty('value');
+    expect(result).toHaveProperty('valid', true);
+    expect(result).toHaveProperty('value', null);
+    expect(result).not.toHaveProperty('error');
+    expect(logSpy).toHaveBeenCalledWith(PROPERTIES_WARNING);
     done();
   });
 
@@ -53,75 +68,21 @@ describe('validateProperties', () => {
     expect(result).not.toHaveProperty('error');
     done();
   });
-});
 
-describe('validateEvaluationOptions', () => {
-  test('should return error on invalid options', done => {
-    const expected = 'options must be a plain object.';
-    const result = validateEvaluationOptions('test');
-    expect(result).toHaveProperty('valid', false);
-    expect(result).toHaveProperty('error', expected);
-    expect(result).not.toHaveProperty('value');
-    done();
-  });
-
-  test('should return error on invalid options 2', done => {
-    const expected = 'options must be a plain object.';
-    const result = validateEvaluationOptions('[]');
-    expect(result).toHaveProperty('valid', false);
-    expect(result).toHaveProperty('error', expected);
-    expect(result).not.toHaveProperty('value');
-    done();
-  });
-
-  test('should return error on invalid options 3', done => {
-    const expected = 'options must be a plain object.';
-    const result = validateEvaluationOptions('true');
-    expect(result).toHaveProperty('valid', false);
-    expect(result).toHaveProperty('error', expected);
-    expect(result).not.toHaveProperty('value');
-    done();
-  });
-
-  test('should be valid when options is an object', done => {
-    const result = validateEvaluationOptions('{"foo":1}');
-    expect(result).toHaveProperty('valid', true);
-    expect(result).toHaveProperty('value', { foo: 1 });
-    expect(result).not.toHaveProperty('error');
-    done();
-  });
-
-  test('should be valid when options is empty object', done => {
-    const result = validateEvaluationOptions('{}');
-    expect(result).toHaveProperty('valid', true);
-    expect(result).toHaveProperty('value', {});
-    expect(result).not.toHaveProperty('error');
-    done();
-  });
-
-  test('should be valid when options is null', done => {
-    const result = validateEvaluationOptions();
+  test('should not return error if properties has more than 15 keys (enforced)', done => {
+    const result = validateProperties(invalidObj, true);
     expect(result).toHaveProperty('valid', true);
     expect(result).toHaveProperty('value', null);
     expect(result).not.toHaveProperty('error');
+    expect(logSpy).toHaveBeenCalledWith(PROPERTIES_KEY_LIMIT_WARNING);
     done();
   });
 
-  test('should return error if options.properties is not valid', done => {
-    const expected = 'properties must be a plain object with only boolean, string, number or null values.';
-    const result = validateEvaluationOptions('{"properties": "not-an-object"}');
-    expect(result).toHaveProperty('valid', false);
-    expect(result).toHaveProperty('error', expected);
-    expect(result).not.toHaveProperty('value');
-    done();
-  });
-
-  test('should be valid if options.properties is valid', done => {
-    const result = validateEvaluationOptions('{"properties": {"foo": 1, "bar": "baz", "baz": true}}');
+  test('should be valid if properties has more than 15 keys (not enforced)', done => {
+    const result = validateProperties(invalidObj, false);
     expect(result).toHaveProperty('valid', true);
-    expect(result).toHaveProperty('value', { foo: 1, bar: 'baz', baz: true });
+    expect(result).toHaveProperty('value', invalidObj);
     expect(result).not.toHaveProperty('error');
     done();
   });
-
 });

--- a/utils/inputValidation/properties.js
+++ b/utils/inputValidation/properties.js
@@ -1,8 +1,8 @@
 const { isObject, isString } = require('../lang');
-const errorWrapper = require('./wrapper/error');
 const okWrapper = require('./wrapper/ok');
+const { PROPERTIES_WARNING, PROPERTIES_KEY_LIMIT_WARNING } = require('../constants');
 
-function validateProperties(maybeProperties) {
+function validateProperties(maybeProperties, enforceKeyLimit = false) {
   // @TODO make the validation more specific
   // eslint-disable-next-line eqeqeq
   if (maybeProperties == undefined) return okWrapper(null);
@@ -10,33 +10,21 @@ function validateProperties(maybeProperties) {
   try {
     properties = isString(maybeProperties) ? JSON.parse(maybeProperties) : maybeProperties;
     if (!isObject(properties)) {
-      return errorWrapper('properties must be a plain object with only boolean, string, number or null values.');
+      console.log(PROPERTIES_WARNING);
+      properties = null;
+    }
+    const keys = Object.keys(properties);
+    if (enforceKeyLimit && keys.length > 15) {
+      console.log(PROPERTIES_KEY_LIMIT_WARNING);
+      properties = null;
     }
     return okWrapper(properties);
   } catch (e) {
-    return errorWrapper('properties must be a plain object with only boolean, string, number or null values.');
-  }
-}
-
-function validateEvaluationOptions(maybeOptions) {
-  // eslint-disable-next-line eqeqeq
-  if (maybeOptions == undefined) return okWrapper(null);
-  let options;
-  try {
-    options = isString(maybeOptions) ? JSON.parse(maybeOptions) : maybeOptions;
-    if (!isObject(options)) {
-      return errorWrapper('options must be a plain object.');
-    }
-    if ('properties' in options) {
-      return validateProperties(options.properties);
-    }
-    return okWrapper(options);
-  } catch (e) {
-    return errorWrapper('options must be a plain object.');
+    console.log(PROPERTIES_WARNING);
+    return okWrapper(null);
   }
 }
 
 module.exports = {
   validateProperties,
-  validateEvaluationOptions,
 };

--- a/utils/mocks/splitchanges.since.-1.till.1602796638344.json
+++ b/utils/mocks/splitchanges.since.-1.till.1602796638344.json
@@ -43,6 +43,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": true,
         "prerequisites": [
           { "n": "flag1", "ts": ["on","v1"] }, 
           { "n": "flag2", "ts": ["off"] }
@@ -90,6 +91,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": false,
         "prerequisites": []
       },
       {
@@ -136,6 +138,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": true,
         "prerequisites": [
           { "n": "flag3", "ts": ["on","v2"] }, 
           { "n": "flag4", "ts": ["off"] },
@@ -184,6 +187,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": false,
         "prerequisites": []
       },
       {
@@ -230,6 +234,7 @@
             "label": "default rule"
           }
         ],
+        "impressionsDisabled": true,
         "prerequisites": []
       }
     ],


### PR DESCRIPTION
# Split Evaluator

## What did you accomplish?

Use properties param instead of options for impressions properties feature
Modified functionality to log a warning and ignore properties if are invalid and send the impression anyways.
Added maximum of 15 keys for properties sent as query params in GET requests (no limits for POST requests)

Update /manager/split and /manager/splits responses in api-docs to add impressionsDisabled and prerequisites properties
Update get treatment/s related definitions in open-api to add options parameter
Added impressions disabled property to split and splits tests
Added tests coverage
Updated api-docs page

